### PR TITLE
Fix column-major parameter ordering in parameterized matmul

### DIFF
--- a/include/subexpr.h
+++ b/include/subexpr.h
@@ -37,7 +37,9 @@ typedef struct parameter_expr
 {
     expr base;
     int param_id;
-    bool has_been_refreshed;
+    /* Set to true by problem_update_params(), cleared by
+       refresh_param_values() after propagating new values. */
+    bool needs_refresh;
 } parameter_expr;
 
 /* Linear operator: y = A * x + b

--- a/include/utils/dense_matrix.h
+++ b/include/utils/dense_matrix.h
@@ -17,4 +17,6 @@ Matrix *new_dense_matrix(int m, int n, const double *data);
 /* Transpose helper */
 Matrix *dense_matrix_trans(const Dense_Matrix *self);
 
+void A_transpose(double *AT, const double *A, int m, int n);
+
 #endif /* DENSE_MATRIX_H */

--- a/src/atoms/affine/left_matmul.c
+++ b/src/atoms/affine/left_matmul.c
@@ -170,17 +170,17 @@ static void refresh_sparse_left(left_matmul_expr *lnode)
 {
     Sparse_Matrix *sm_A = (Sparse_Matrix *) lnode->A;
     Sparse_Matrix *sm_AT = (Sparse_Matrix *) lnode->AT;
-    CSR_Matrix *csr = sm_A->csr;
-    const double *vals = lnode->param_source->value;
+    CSR_Matrix *A = sm_A->csr;
+    const double *param_vals = lnode->param_source->value;
     int d1 = lnode->param_source->d1;
 
     /* Parameter values are column-major; extract into CSR data order */
-    for (int row = 0; row < csr->m; row++)
+    for (int i = 0; i < A->m; i++)
     {
-        for (int k = csr->p[row]; k < csr->p[row + 1]; k++)
+        for (int jj = A->p[i]; jj < A->p[i + 1]; jj++)
         {
-            int col = csr->i[k];
-            csr->x[k] = vals[col * d1 + row];
+            int j = A->i[jj];
+            A->x[jj] = param_vals[j * d1 + i];
         }
     }
     /* Recompute AT values from A */

--- a/src/atoms/affine/left_matmul.c
+++ b/src/atoms/affine/left_matmul.c
@@ -56,11 +56,11 @@ static void refresh_param_values(left_matmul_expr *lnode)
         return;
     }
     parameter_expr *param = (parameter_expr *) lnode->param_source;
-    if (param->has_been_refreshed)
+    if (!param->needs_refresh)
     {
         return;
     }
-    param->has_been_refreshed = true;
+    param->needs_refresh = false;
     lnode->refresh_param_values(lnode);
 }
 
@@ -168,23 +168,11 @@ static void eval_wsum_hess(expr *node, const double *w)
 
 static void refresh_sparse_left(left_matmul_expr *lnode)
 {
-    Sparse_Matrix *sm_A = (Sparse_Matrix *) lnode->A;
-    Sparse_Matrix *sm_AT = (Sparse_Matrix *) lnode->AT;
-    CSR_Matrix *A = sm_A->csr;
-    const double *param_vals = lnode->param_source->value;
-    int d1 = lnode->param_source->d1;
-
-    /* Parameter values are column-major; extract into CSR data order */
-    for (int i = 0; i < A->m; i++)
-    {
-        for (int jj = A->p[i]; jj < A->p[i + 1]; jj++)
-        {
-            int j = A->i[jj];
-            A->x[jj] = param_vals[j * d1 + i];
-        }
-    }
-    /* Recompute AT values from A */
-    AT_fill_values(sm_A->csr, sm_AT->csr, lnode->base.work->iwork);
+    (void) lnode;
+    fprintf(stderr,
+            "Error in refresh_sparse_left: parameter for a sparse matrix not "
+            "supported \n");
+    exit(1);
 }
 
 static void refresh_dense_left(left_matmul_expr *lnode)
@@ -198,7 +186,7 @@ static void refresh_dense_left(left_matmul_expr *lnode)
        In this diffengine, we store A in row-major order. Hence, param->vals
        actually corresponds to the transpose of A, and we transpose AT to get A. */
     memcpy(dm_AT->x, lnode->param_source->value, m * n * sizeof(double));
-    A_transpose(dm_A->x, dm_AT->x, m, n);
+    A_transpose(dm_A->x, dm_AT->x, n, m);
 }
 
 expr *new_left_matmul(expr *param_node, expr *u, const CSR_Matrix *A)
@@ -252,6 +240,11 @@ expr *new_left_matmul(expr *param_node, expr *u, const CSR_Matrix *A)
     lnode->param_source = param_node;
     if (param_node != NULL)
     {
+
+        fprintf(stderr, "Error in new_left_matmul: parameter for a sparse matrix "
+                        "not supported \n");
+        exit(1);
+
         expr_retain(param_node);
         lnode->refresh_param_values = refresh_sparse_left;
     }

--- a/src/atoms/affine/left_matmul.c
+++ b/src/atoms/affine/left_matmul.c
@@ -193,18 +193,12 @@ static void refresh_dense_left(left_matmul_expr *lnode)
     Dense_Matrix *dm_AT = (Dense_Matrix *) lnode->AT;
     int m = dm_A->base.m;
     int n = dm_A->base.n;
-    const double *vals = lnode->param_source->value;
 
-    /* Column-major A is row-major AT; copy directly into AT */
-    memcpy(dm_AT->x, vals, m * n * sizeof(double));
-    /* Transpose AT to get row-major A */
-    for (int i = 0; i < m; i++)
-    {
-        for (int j = 0; j < n; j++)
-        {
-            dm_A->x[i * n + j] = dm_AT->x[j * m + i];
-        }
-    }
+    /* The parameter represents the A in left_matmul_dense(A, x) in column-major.
+       In this diffengine, we store A in row-major order. Hence, param->vals
+       actually corresponds to the transpose of A, and we transpose AT to get A. */
+    memcpy(dm_AT->x, lnode->param_source->value, m * n * sizeof(double));
+    A_transpose(dm_A->x, dm_AT->x, m, n);
 }
 
 expr *new_left_matmul(expr *param_node, expr *u, const CSR_Matrix *A)

--- a/src/atoms/affine/left_matmul.c
+++ b/src/atoms/affine/left_matmul.c
@@ -170,7 +170,19 @@ static void refresh_sparse_left(left_matmul_expr *lnode)
 {
     Sparse_Matrix *sm_A = (Sparse_Matrix *) lnode->A;
     Sparse_Matrix *sm_AT = (Sparse_Matrix *) lnode->AT;
-    lnode->A->update_values(lnode->A, lnode->param_source->value);
+    CSR_Matrix *csr = sm_A->csr;
+    const double *vals = lnode->param_source->value;
+    int d1 = lnode->param_source->d1;
+
+    /* Parameter values are column-major; extract into CSR data order */
+    for (int row = 0; row < csr->m; row++)
+    {
+        for (int k = csr->p[row]; k < csr->p[row + 1]; k++)
+        {
+            int col = csr->i[k];
+            csr->x[k] = vals[col * d1 + row];
+        }
+    }
     /* Recompute AT values from A */
     AT_fill_values(sm_A->csr, sm_AT->csr, lnode->base.work->iwork);
 }
@@ -178,16 +190,19 @@ static void refresh_sparse_left(left_matmul_expr *lnode)
 static void refresh_dense_left(left_matmul_expr *lnode)
 {
     Dense_Matrix *dm_A = (Dense_Matrix *) lnode->A;
+    Dense_Matrix *dm_AT = (Dense_Matrix *) lnode->AT;
     int m = dm_A->base.m;
     int n = dm_A->base.n;
-    lnode->A->update_values(lnode->A, lnode->param_source->value);
-    /* Recompute AT data (transpose of row-major A) */
-    Dense_Matrix *dm_AT = (Dense_Matrix *) lnode->AT;
+    const double *vals = lnode->param_source->value;
+
+    /* Column-major A is row-major AT; copy directly into AT */
+    memcpy(dm_AT->x, vals, m * n * sizeof(double));
+    /* Transpose AT to get row-major A */
     for (int i = 0; i < m; i++)
     {
         for (int j = 0; j < n; j++)
         {
-            dm_AT->x[j * m + i] = dm_A->x[i * n + j];
+            dm_A->x[i * n + j] = dm_AT->x[j * m + i];
         }
     }
 }

--- a/src/atoms/affine/parameter.c
+++ b/src/atoms/affine/parameter.c
@@ -65,7 +65,7 @@ expr *new_parameter(int d1, int d2, int param_id, int n_vars, const double *valu
               is_affine, wsum_hess_init_impl, eval_wsum_hess, NULL);
 
     pnode->param_id = param_id;
-    pnode->has_been_refreshed = false;
+    pnode->needs_refresh = false;
 
     if (values != NULL)
     {

--- a/src/atoms/affine/right_matmul.c
+++ b/src/atoms/affine/right_matmul.c
@@ -72,8 +72,7 @@ static void refresh_dense_right(left_matmul_expr *lnode)
     {
         for (int j = 0; j < n_orig; j++)
         {
-            dm_A_inner->x[i * n_orig + j] =
-                dm_AT_inner->x[j * m_orig + i];
+            dm_A_inner->x[i * n_orig + j] = dm_AT_inner->x[j * m_orig + i];
         }
     }
 }

--- a/src/atoms/affine/right_matmul.c
+++ b/src/atoms/affine/right_matmul.c
@@ -40,8 +40,19 @@ static void refresh_sparse_right(left_matmul_expr *lnode)
 {
     Sparse_Matrix *sm_AT_inner = (Sparse_Matrix *) lnode->A;
     Sparse_Matrix *sm_A_inner = (Sparse_Matrix *) lnode->AT;
-    /* lnode->AT holds the original A; update its values from param */
-    lnode->AT->update_values(lnode->AT, lnode->param_source->value);
+    CSR_Matrix *csr_A = sm_A_inner->csr;
+    const double *vals = lnode->param_source->value;
+    int d1 = lnode->param_source->d1;
+
+    /* Parameter values are column-major; extract into CSR data order */
+    for (int row = 0; row < csr_A->m; row++)
+    {
+        for (int k = csr_A->p[row]; k < csr_A->p[row + 1]; k++)
+        {
+            int col = csr_A->i[k];
+            csr_A->x[k] = vals[col * d1 + row];
+        }
+    }
     /* Recompute A^T (lnode->A) from A (lnode->AT) */
     AT_fill_values(sm_A_inner->csr, sm_AT_inner->csr, lnode->base.work->iwork);
 }
@@ -50,16 +61,19 @@ static void refresh_dense_right(left_matmul_expr *lnode)
 {
     Dense_Matrix *dm_AT_inner = (Dense_Matrix *) lnode->A;
     Dense_Matrix *dm_A_inner = (Dense_Matrix *) lnode->AT;
-    int m_orig = dm_A_inner->base.m; /* original A is m x n */
+    int m_orig = dm_A_inner->base.m;
     int n_orig = dm_A_inner->base.n;
-    /* Update original A (inner's AT) from param values */
-    lnode->AT->update_values(lnode->AT, lnode->param_source->value);
-    /* Recompute A^T (inner's A) from A */
+    const double *vals = lnode->param_source->value;
+
+    /* Column-major A is row-major AT; copy directly into inner A (= A^T) */
+    memcpy(dm_AT_inner->x, vals, m_orig * n_orig * sizeof(double));
+    /* Transpose to get row-major A (inner's AT = original A) */
     for (int i = 0; i < m_orig; i++)
     {
         for (int j = 0; j < n_orig; j++)
         {
-            dm_AT_inner->x[j * m_orig + i] = dm_A_inner->x[i * n_orig + j];
+            dm_A_inner->x[i * n_orig + j] =
+                dm_AT_inner->x[j * m_orig + i];
         }
     }
 }

--- a/src/atoms/affine/right_matmul.c
+++ b/src/atoms/affine/right_matmul.c
@@ -20,6 +20,7 @@
 #include "utils/CSR_Matrix.h"
 #include "utils/dense_matrix.h"
 #include "utils/tracked_alloc.h"
+#include <stdio.h>
 #include <stdlib.h>
 
 /* This file implements the atom 'right_matmul' corresponding to the operation y =
@@ -38,23 +39,11 @@
    So: update lnode->AT from param values, then recompute lnode->A. */
 static void refresh_sparse_right(left_matmul_expr *lnode)
 {
-    Sparse_Matrix *sm_AT_inner = (Sparse_Matrix *) lnode->A;
-    Sparse_Matrix *sm_A_inner = (Sparse_Matrix *) lnode->AT;
-    CSR_Matrix *csr_A = sm_A_inner->csr;
-    const double *vals = lnode->param_source->value;
-    int d1 = lnode->param_source->d1;
-
-    /* Parameter values are column-major; extract into CSR data order */
-    for (int row = 0; row < csr_A->m; row++)
-    {
-        for (int k = csr_A->p[row]; k < csr_A->p[row + 1]; k++)
-        {
-            int col = csr_A->i[k];
-            csr_A->x[k] = vals[col * d1 + row];
-        }
-    }
-    /* Recompute A^T (lnode->A) from A (lnode->AT) */
-    AT_fill_values(sm_A_inner->csr, sm_AT_inner->csr, lnode->base.work->iwork);
+    (void) lnode;
+    fprintf(stderr,
+            "Error in refresh_sparse_right: parameter for a sparse matrix not "
+            "supported \n");
+    exit(1);
 }
 
 static void refresh_dense_right(left_matmul_expr *lnode)
@@ -87,6 +76,11 @@ expr *new_right_matmul(expr *param_node, expr *u, const CSR_Matrix *A)
        left_matmul */
     if (param_node != NULL)
     {
+
+        fprintf(stderr, "Error in new_right_matmul: parameter for a sparse matrix "
+                        "not supported \n");
+        exit(1);
+
         left_matmul_expr *lnode = (left_matmul_expr *) left_matmul;
         lnode->param_source = param_node;
         expr_retain(param_node);

--- a/src/atoms/affine/right_matmul.c
+++ b/src/atoms/affine/right_matmul.c
@@ -59,22 +59,18 @@ static void refresh_sparse_right(left_matmul_expr *lnode)
 
 static void refresh_dense_right(left_matmul_expr *lnode)
 {
-    Dense_Matrix *dm_AT_inner = (Dense_Matrix *) lnode->A;
-    Dense_Matrix *dm_A_inner = (Dense_Matrix *) lnode->AT;
-    int m_orig = dm_A_inner->base.m;
-    int n_orig = dm_A_inner->base.n;
-    const double *vals = lnode->param_source->value;
+    /* This left_matmul_expr node corresponds to left multiplication with B = AT,
+       where A is the original (m x n) matrix given to the right_matmul function.
+       Furthermore, lnode->param_source->value corresponds to the column-major
+       version of A, which is BT (an m x n matrix) */
 
-    /* Column-major A is row-major AT; copy directly into inner A (= A^T) */
-    memcpy(dm_AT_inner->x, vals, m_orig * n_orig * sizeof(double));
-    /* Transpose to get row-major A (inner's AT = original A) */
-    for (int i = 0; i < m_orig; i++)
-    {
-        for (int j = 0; j < n_orig; j++)
-        {
-            dm_A_inner->x[i * n_orig + j] = dm_AT_inner->x[j * m_orig + i];
-        }
-    }
+    Dense_Matrix *B = (Dense_Matrix *) lnode->AT;
+    Dense_Matrix *BT = (Dense_Matrix *) lnode->A;
+    int m = B->base.n;
+    int n = B->base.m;
+
+    memcpy(BT->x, lnode->param_source->value, m * n * sizeof(double));
+    A_transpose(B->x, BT->x, m, n);
 }
 
 expr *new_right_matmul(expr *param_node, expr *u, const CSR_Matrix *A)
@@ -107,16 +103,9 @@ expr *new_right_matmul(expr *param_node, expr *u, const CSR_Matrix *A)
 expr *new_right_matmul_dense(expr *param_node, expr *u, int m, int n,
                              const double *data)
 {
-    /* We express: u @ A = (A^T @ u^T)^T
-       A is m x n, so A^T is n x m. */
+    /* We express: u @ A = (A^T @ u^T)^T. A is m x n, so A^T is n x m. */
     double *AT = (double *) SP_MALLOC(n * m * sizeof(double));
-    for (int i = 0; i < m; i++)
-    {
-        for (int j = 0; j < n; j++)
-        {
-            AT[j * m + i] = data[i * n + j];
-        }
-    }
+    A_transpose(AT, data, m, n);
 
     expr *u_transpose = new_transpose(u);
     expr *left_matmul_node = new_left_matmul_dense(NULL, u_transpose, n, m, AT);

--- a/src/problem.c
+++ b/src/problem.c
@@ -382,7 +382,7 @@ void problem_update_params(problem *prob, const double *theta)
         if (param->param_id == PARAM_FIXED) continue;
         int offset = param->param_id;
         memcpy(pnode->value, theta + offset, pnode->size * sizeof(double));
-        param->has_been_refreshed = false;
+        param->needs_refresh = true;
     }
 
     /* Force re-evaluation of affine Jacobians on next call */

--- a/src/utils/dense_matrix.c
+++ b/src/utils/dense_matrix.c
@@ -78,15 +78,20 @@ Matrix *dense_matrix_trans(const Dense_Matrix *A)
     int n = A->base.n;
     double *AT_x = (double *) SP_MALLOC(m * n * sizeof(double));
 
-    for (int i = 0; i < m; i++)
-    {
-        for (int j = 0; j < n; j++)
-        {
-            AT_x[j * m + i] = A->x[i * n + j];
-        }
-    }
+    A_transpose(AT_x, A->x, m, n);
 
     Matrix *result = new_dense_matrix(n, m, AT_x);
     free(AT_x);
     return result;
+}
+
+void A_transpose(double *AT, const double *A, int m, int n)
+{
+    for (int i = 0; i < m; i++)
+    {
+        for (int j = 0; j < n; j++)
+        {
+            AT[j * m + i] = A[i * n + j];
+        }
+    }
 }

--- a/tests/all_tests.c
+++ b/tests/all_tests.c
@@ -355,6 +355,7 @@ int main(void)
     mu_run_test(test_param_left_matmul_problem, tests_run);
     mu_run_test(test_param_right_matmul_problem, tests_run);
     mu_run_test(test_param_left_matmul_rectangular, tests_run);
+    mu_run_test(test_param_right_matmul_rectangular, tests_run);
     mu_run_test(test_param_fixed_skip_in_update, tests_run);
 #endif /* PROFILE_ONLY */
 

--- a/tests/all_tests.c
+++ b/tests/all_tests.c
@@ -355,7 +355,6 @@ int main(void)
     mu_run_test(test_param_left_matmul_problem, tests_run);
     mu_run_test(test_param_right_matmul_problem, tests_run);
     mu_run_test(test_param_left_matmul_rectangular, tests_run);
-    mu_run_test(test_param_left_matmul_sparse, tests_run);
     mu_run_test(test_param_fixed_skip_in_update, tests_run);
 #endif /* PROFILE_ONLY */
 

--- a/tests/all_tests.c
+++ b/tests/all_tests.c
@@ -354,6 +354,8 @@ int main(void)
     mu_run_test(test_param_vector_mult_problem, tests_run);
     mu_run_test(test_param_left_matmul_problem, tests_run);
     mu_run_test(test_param_right_matmul_problem, tests_run);
+    mu_run_test(test_param_left_matmul_rectangular, tests_run);
+    mu_run_test(test_param_left_matmul_sparse, tests_run);
     mu_run_test(test_param_fixed_skip_in_update, tests_run);
 #endif /* PROFILE_ONLY */
 

--- a/tests/problem/test_param_prob.h
+++ b/tests/problem/test_param_prob.h
@@ -164,14 +164,14 @@ const char *test_param_vector_mult_problem(void)
  * Test 3: left_param_matmul in constraint
  *
  * Problem: minimize sum(x), subject to A @ x, x size 2, A is 2x2
- *   A is a 2x2 matrix parameter (param_id=0, size=4, CSR data order)
- *   A = [[1,2],[3,4]] → CSR data order theta = [1,2,3,4]
+ *   A is a 2x2 matrix parameter (param_id=0, size=4, column-major order)
+ *   A = [[1,2],[3,4]] → column-major theta = [1,3,2,4]
  *
  * At x=[1,2]:
  *   constraint_values = [1*1+2*2, 3*1+4*2] = [5, 11]
  *   jacobian = [[1,2],[3,4]]
  *
- * After update A = [[5,6],[7,8]] → theta = [5,6,7,8]:
+ * After update A = [[5,6],[7,8]] → column-major theta = [5,7,6,8]:
  *   constraint_values = [5*1+6*2, 7*1+8*2] = [17, 23]
  *   jacobian = [[5,6],[7,8]]
  */
@@ -208,8 +208,8 @@ const char *test_param_left_matmul_problem(void)
     problem_register_params(prob, param_nodes, 1);
     problem_init_derivatives(prob);
 
-    /* Set A = [[1,2],[3,4]], CSR data order: [1,2,3,4] */
-    double theta[4] = {1.0, 2.0, 3.0, 4.0};
+    /* Set A = [[1,2],[3,4]], column-major: [1,3,2,4] */
+    double theta[4] = {1.0, 3.0, 2.0, 4.0};
     problem_update_params(prob, theta);
 
     double u[2] = {1.0, 2.0};
@@ -233,8 +233,8 @@ const char *test_param_left_matmul_problem(void)
     double expected_x[4] = {1.0, 2.0, 3.0, 4.0};
     mu_assert("jac->x wrong (A1)", cmp_double_array(jac->x, expected_x, 4));
 
-    /* Update A = [[5,6],[7,8]], CSR data order: [5,6,7,8] */
-    double theta2[4] = {5.0, 6.0, 7.0, 8.0};
+    /* Update A = [[5,6],[7,8]], column-major: [5,7,6,8] */
+    double theta2[4] = {5.0, 7.0, 6.0, 8.0};
     problem_update_params(prob, theta2);
 
     problem_constraint_forward(prob, u);
@@ -256,14 +256,14 @@ const char *test_param_left_matmul_problem(void)
  * Test 4: right_param_matmul in constraint
  *
  * Problem: minimize sum(x), subject to x @ A, x size 1x2, A is 2x2
- *   A is a 2x2 matrix parameter (param_id=0, size=4, CSR data order)
- *   A = [[1,2],[3,4]] → CSR data order theta = [1,2,3,4]
+ *   A is a 2x2 matrix parameter (param_id=0, size=4, column-major order)
+ *   A = [[1,2],[3,4]] → column-major theta = [1,3,2,4]
  *
  * At x=[1,2]:
  *   constraint_values = [1*1+2*3, 1*2+2*4] = [7, 10]
  *   jacobian = [[1,3],[2,4]] = A^T
  *
- * After update A = [[5,6],[7,8]] → theta = [5,6,7,8]:
+ * After update A = [[5,6],[7,8]] → column-major theta = [5,7,6,8]:
  *   constraint_values = [1*5+2*7, 1*6+2*8] = [19, 22]
  *   jacobian = [[5,7],[6,8]] = A^T
  */
@@ -300,8 +300,8 @@ const char *test_param_right_matmul_problem(void)
     problem_register_params(prob, param_nodes, 1);
     problem_init_derivatives(prob);
 
-    /* Set A = [[1,2],[3,4]], CSR data order: [1,2,3,4] */
-    double theta[4] = {1.0, 2.0, 3.0, 4.0};
+    /* Set A = [[1,2],[3,4]], column-major: [1,3,2,4] */
+    double theta[4] = {1.0, 3.0, 2.0, 4.0};
     problem_update_params(prob, theta);
 
     double u[2] = {1.0, 2.0};
@@ -325,8 +325,8 @@ const char *test_param_right_matmul_problem(void)
     double expected_x[4] = {1.0, 3.0, 2.0, 4.0};
     mu_assert("jac->x wrong (A1)", cmp_double_array(jac->x, expected_x, 4));
 
-    /* Update A = [[5,6],[7,8]], CSR data order: [5,6,7,8] */
-    double theta2[4] = {5.0, 6.0, 7.0, 8.0};
+    /* Update A = [[5,6],[7,8]], column-major: [5,7,6,8] */
+    double theta2[4] = {5.0, 7.0, 6.0, 8.0};
     problem_update_params(prob, theta2);
 
     problem_constraint_forward(prob, u);
@@ -419,6 +419,139 @@ const char *test_param_fixed_skip_in_update(void)
     double expected_grad2[2] = {7.0, 6.0};
     mu_assert("gradient wrong (b=5)",
               cmp_double_array(prob->gradient_values, expected_grad2, 2));
+
+    free_problem(prob);
+
+    return 0;
+}
+
+/*
+ * Test 6: left_param_matmul with rectangular 3x2 matrix
+ *
+ * Problem: minimize sum(x), subject to A @ x, x size 2, A is 3x2
+ *   A = [[1,2],[3,4],[5,6]] → column-major theta = [1,3,5,2,4,6]
+ *
+ * At x=[1,2]:
+ *   constraint_values = [1+4, 3+8, 5+12] = [5, 11, 17]
+ *   jacobian = [[1,2],[3,4],[5,6]]
+ */
+const char *test_param_left_matmul_rectangular(void)
+{
+    int n_vars = 2;
+
+    /* Objective: sum(x) */
+    expr *x_obj = new_variable(2, 1, 0, n_vars);
+    expr *objective = new_sum(x_obj, -1);
+
+    /* Constraint: A @ x, A is 3x2 */
+    expr *x_con = new_variable(2, 1, 0, n_vars);
+    expr *A_param = new_parameter(3, 2, 0, n_vars, NULL);
+
+    /* Dense 3x2 CSR */
+    CSR_Matrix *A = new_csr_matrix(3, 2, 6);
+    int Ap[4] = {0, 2, 4, 6};
+    int Ai[6] = {0, 1, 0, 1, 0, 1};
+    double Ax[6] = {0, 0, 0, 0, 0, 0};
+    memcpy(A->p, Ap, 4 * sizeof(int));
+    memcpy(A->i, Ai, 6 * sizeof(int));
+    memcpy(A->x, Ax, 6 * sizeof(double));
+
+    expr *constraint = new_left_matmul(A_param, x_con, A);
+    free_csr_matrix(A);
+
+    expr *constraints[1] = {constraint};
+
+    problem *prob = new_problem(objective, constraints, 1, false);
+
+    expr *param_nodes[1] = {A_param};
+    problem_register_params(prob, param_nodes, 1);
+    problem_init_derivatives(prob);
+
+    /* Set A = [[1,2],[3,4],[5,6]], column-major: [1,3,5,2,4,6] */
+    double theta[6] = {1.0, 3.0, 5.0, 2.0, 4.0, 6.0};
+    problem_update_params(prob, theta);
+
+    double u[2] = {1.0, 2.0};
+    problem_constraint_forward(prob, u);
+    problem_jacobian(prob);
+
+    double expected_cv[3] = {5.0, 11.0, 17.0};
+    mu_assert("rect constraint values wrong",
+              cmp_double_array(prob->constraint_values, expected_cv, 3));
+
+    CSR_Matrix *jac = prob->jacobian;
+    double expected_x[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    mu_assert("rect jac->x wrong", cmp_double_array(jac->x, expected_x, 6));
+
+    free_problem(prob);
+
+    return 0;
+}
+
+/*
+ * Test 7: left_param_matmul with sparse matrix (structural zeros)
+ *
+ * Problem: minimize sum(x), subject to A @ x, x size 3, A is 3x3 sparse
+ *   A = [[1, 0, 2],
+ *        [0, 3, 0],
+ *        [4, 0, 5]]
+ *   CSR: p=[0,2,3,5], i=[0,2, 1, 0,2], nnz=5
+ *   Column-major theta (full 9 values): [1,0,4, 0,3,0, 2,0,5]
+ *
+ * At x=[1,2,3]:
+ *   constraint_values = [1+6, 6, 4+15] = [7, 6, 19]
+ *   jacobian = A
+ */
+const char *test_param_left_matmul_sparse(void)
+{
+    int n_vars = 3;
+
+    /* Objective: sum(x) */
+    expr *x_obj = new_variable(3, 1, 0, n_vars);
+    expr *objective = new_sum(x_obj, -1);
+
+    /* Constraint: A @ x, A is 3x3 sparse */
+    expr *x_con = new_variable(3, 1, 0, n_vars);
+    expr *A_param = new_parameter(3, 3, 0, n_vars, NULL);
+
+    CSR_Matrix *A = new_csr_matrix(3, 3, 5);
+    int Ap[4] = {0, 2, 3, 5};
+    int Ai[5] = {0, 2, 1, 0, 2};
+    double Ax[5] = {0, 0, 0, 0, 0};
+    memcpy(A->p, Ap, 4 * sizeof(int));
+    memcpy(A->i, Ai, 5 * sizeof(int));
+    memcpy(A->x, Ax, 5 * sizeof(double));
+
+    expr *constraint = new_left_matmul(A_param, x_con, A);
+    free_csr_matrix(A);
+
+    expr *constraints[1] = {constraint};
+
+    problem *prob = new_problem(objective, constraints, 1, false);
+
+    expr *param_nodes[1] = {A_param};
+    problem_register_params(prob, param_nodes, 1);
+    problem_init_derivatives(prob);
+
+    /* A = [[1,0,2],[0,3,0],[4,0,5]], column-major: [1,0,4, 0,3,0, 2,0,5] */
+    double theta[9] = {1.0, 0.0, 4.0, 0.0, 3.0, 0.0, 2.0, 0.0, 5.0};
+    problem_update_params(prob, theta);
+
+    double u[3] = {1.0, 2.0, 3.0};
+    problem_constraint_forward(prob, u);
+    problem_jacobian(prob);
+
+    double expected_cv[3] = {7.0, 6.0, 19.0};
+    mu_assert("sparse constraint values wrong",
+              cmp_double_array(prob->constraint_values, expected_cv, 3));
+
+    CSR_Matrix *jac = prob->jacobian;
+    mu_assert("sparse jac nnz wrong", jac->nnz == 5);
+
+    /* CSR data order: row0=[1,2], row1=[3], row2=[4,5] */
+    double expected_x[5] = {1.0, 2.0, 3.0, 4.0, 5.0};
+    mu_assert("sparse jac->x wrong",
+              cmp_double_array(jac->x, expected_x, 5));
 
     free_problem(prob);
 

--- a/tests/problem/test_param_prob.h
+++ b/tests/problem/test_param_prob.h
@@ -340,4 +340,64 @@ const char *test_param_left_matmul_rectangular(void)
     return 0;
 }
 
+const char *test_param_right_matmul_rectangular(void)
+{
+    int n = 2;
+
+    /* minimize sum(x) subject to xA = ?, with A parameter (2x3) */
+    expr *x = new_variable(1, 2, 0, n);
+    expr *objective = new_sum(x, -1);
+    expr *A_param = new_parameter(2, 3, 0, n, NULL);
+
+    /* dense 2x3 matrix */
+    double Ax[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    expr *constraint = new_right_matmul_dense(A_param, x, 2, 3, Ax);
+    expr *constraints[1] = {constraint};
+    problem *prob = new_problem(objective, constraints, 1, false);
+
+    /* register parameters and fill sparsity patterns */
+    expr *param_nodes[1] = {A_param};
+    problem_register_params(prob, param_nodes, 1);
+    problem_init_derivatives(prob);
+
+    /* point for evaluating and utilities for test */
+    double x_vals[2] = {1.0, 2.0};
+    int Ap[4] = {0, 2, 4, 6};
+    int Ai[6] = {0, 1, 0, 1, 0, 1};
+
+    /* test 1: initial jacobian */
+    problem_constraint_forward(prob, x_vals);
+    double constrs[3] = {9.0, 12.0, 15.0};
+    problem_jacobian(prob);
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 3));
+    mu_assert("rows fail", cmp_int_array(prob->jacobian->p, Ap, 4));
+    mu_assert("cols fail", cmp_int_array(prob->jacobian->i, Ai, 6));
+    double jac_x[6] = {1.0, 4.0, 2.0, 5.0, 3.0, 6.0};
+    mu_assert("vals fail", cmp_double_array(prob->jacobian->x, jac_x, 6));
+
+    /* test 2: A = [[7,8,9],[10,11,12]] (column-major [7,10,8,11,9,12]) */
+    double theta[6] = {7.0, 10.0, 8.0, 11.0, 9.0, 12.0};
+    problem_update_params(prob, theta);
+    problem_constraint_forward(prob, x_vals);
+    problem_jacobian(prob);
+    constrs[0] = 27.0;
+    constrs[1] = 30.0;
+    constrs[2] = 33.0;
+    jac_x[0] = 7.0;
+    jac_x[1] = 10.0;
+    jac_x[2] = 8.0;
+    jac_x[3] = 11.0;
+    jac_x[4] = 9.0;
+    jac_x[5] = 12.0;
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 3));
+    mu_assert("vals fail", cmp_double_array(prob->jacobian->x, jac_x, 6));
+    mu_assert("rows fail", cmp_int_array(prob->jacobian->p, Ap, 4));
+    mu_assert("cols fail", cmp_int_array(prob->jacobian->i, Ai, 6));
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 3));
+
+    free_problem(prob);
+
+    return 0;
+}
+
 #endif /* TEST_PARAM_PROB_H */

--- a/tests/problem/test_param_prob.h
+++ b/tests/problem/test_param_prob.h
@@ -550,8 +550,7 @@ const char *test_param_left_matmul_sparse(void)
 
     /* CSR data order: row0=[1,2], row1=[3], row2=[4,5] */
     double expected_x[5] = {1.0, 2.0, 3.0, 4.0, 5.0};
-    mu_assert("sparse jac->x wrong",
-              cmp_double_array(jac->x, expected_x, 5));
+    mu_assert("sparse jac->x wrong", cmp_double_array(jac->x, expected_x, 5));
 
     free_problem(prob);
 

--- a/tests/problem/test_param_prob.h
+++ b/tests/problem/test_param_prob.h
@@ -13,544 +13,327 @@
 #include "subexpr.h"
 #include "test_helpers.h"
 
-/*
- * Test 1: param_scalar_mult in objective
- *
- * Problem: minimize a * sum(log(x)), no constraints, x size 2
- *   a is a scalar parameter (param_id=0)
- *
- * At x=[1,2], a=3:
- *   obj = 3*(log(1)+log(2)) = 3*log(2)
- *   gradient = [3/1, 3/2] = [3.0, 1.5]
- *
- * After update a=5:
- *   obj = 5*log(2)
- *   gradient = [5.0, 2.5]
- */
 const char *test_param_scalar_mult_problem(void)
 {
-    int n_vars = 2;
+    int n = 2;
 
-    /* Build tree: sum(a * log(x)) */
-    expr *x = new_variable(2, 1, 0, n_vars);
+    /* minimize a * sum(log(x)), with a parameter */
+    expr *x = new_variable(2, 1, 0, n);
     expr *log_x = new_log(x);
-    expr *a_param = new_parameter(1, 1, 0, n_vars, NULL);
+    expr *a_param = new_parameter(1, 1, 0, n, NULL);
     expr *scaled = new_scalar_mult(a_param, log_x);
     expr *objective = new_sum(scaled, -1);
-
-    /* Create problem (no constraints) */
     problem *prob = new_problem(objective, NULL, 0, false);
 
-    /* Register parameter */
+    /* register parameters and fill sparsity patterns */
     expr *param_nodes[1] = {a_param};
     problem_register_params(prob, param_nodes, 1);
     problem_init_derivatives(prob);
 
-    /* Set a=3 and evaluate at x=[1,2] */
+    /* point for evaluating */
+    double x_vals[2] = {1.0, 2.0};
+
+    /* test 1: a=3 */
     double theta[1] = {3.0};
     problem_update_params(prob, theta);
-
-    double u[2] = {1.0, 2.0};
-    double obj_val = problem_objective_forward(prob, u);
+    double obj_val = problem_objective_forward(prob, x_vals);
     problem_gradient(prob);
-
     double expected_obj = 3.0 * log(2.0);
-    mu_assert("obj wrong (a=3)", fabs(obj_val - expected_obj) < 1e-10);
+    mu_assert("vals fail", fabs(obj_val - expected_obj) < 1e-10);
+    double grad[2] = {3.0, 1.5};
+    mu_assert("vals fail", cmp_double_array(prob->gradient_values, grad, 2));
 
-    double expected_grad[2] = {3.0, 1.5};
-    mu_assert("gradient wrong (a=3)",
-              cmp_double_array(prob->gradient_values, expected_grad, 2));
-
-    /* Update a=5 and re-evaluate */
+    /* test 2: a=5 */
     theta[0] = 5.0;
     problem_update_params(prob, theta);
-
-    obj_val = problem_objective_forward(prob, u);
+    obj_val = problem_objective_forward(prob, x_vals);
     problem_gradient(prob);
-
     expected_obj = 5.0 * log(2.0);
-    mu_assert("obj wrong (a=5)", fabs(obj_val - expected_obj) < 1e-10);
-
-    double expected_grad2[2] = {5.0, 2.5};
-    mu_assert("gradient wrong (a=5)",
-              cmp_double_array(prob->gradient_values, expected_grad2, 2));
+    mu_assert("vals fail", fabs(obj_val - expected_obj) < 1e-10);
+    grad[0] = 5.0;
+    grad[1] = 2.5;
+    mu_assert("vals fail", cmp_double_array(prob->gradient_values, grad, 2));
 
     free_problem(prob);
 
     return 0;
 }
 
-/*
- * Test 2: param_vector_mult in constraint
- *
- * Problem: minimize sum(x), subject to p ∘ x, x size 2
- *   p is a vector parameter of size 2 (param_id=0)
- *
- * At x=[1,2], p=[3,4]:
- *   constraint_values = [3, 8]
- *   jacobian = diag([3, 4])
- *
- * After update p=[5,6]:
- *   constraint_values = [5, 12]
- *   jacobian = diag([5, 6])
- */
 const char *test_param_vector_mult_problem(void)
 {
-    int n_vars = 2;
+    int n = 2;
 
-    /* Objective: sum(x) */
-    expr *x_obj = new_variable(2, 1, 0, n_vars);
-    expr *objective = new_sum(x_obj, -1);
-
-    /* Constraint: p ∘ x */
-    expr *x_con = new_variable(2, 1, 0, n_vars);
-    expr *p_param = new_parameter(2, 1, 0, n_vars, NULL);
-    expr *constraint = new_vector_mult(p_param, x_con);
-
+    /* minimize sum(x) subject to p ∘ x, with p parameter */
+    expr *x = new_variable(2, 1, 0, n);
+    expr *objective = new_sum(x, -1);
+    expr *p_param = new_parameter(2, 1, 0, n, NULL);
+    expr *constraint = new_vector_mult(p_param, x);
     expr *constraints[1] = {constraint};
-
-    /* Create problem */
     problem *prob = new_problem(objective, constraints, 1, false);
 
+    /* register parameters and fill sparsity patterns */
     expr *param_nodes[1] = {p_param};
     problem_register_params(prob, param_nodes, 1);
     problem_init_derivatives(prob);
 
-    /* Set p=[3,4] and evaluate at x=[1,2] */
+    /* point for evaluating and utilities for test */
+    double x_vals[2] = {1.0, 2.0};
+    int Ap[3] = {0, 1, 2};
+    int Ai[2] = {0, 1};
+    double Ax[2] = {3.0, 4.0};
+
+    /* test 1: p=[3,4] */
     double theta[2] = {3.0, 4.0};
     problem_update_params(prob, theta);
-
-    double u[2] = {1.0, 2.0};
-    problem_constraint_forward(prob, u);
+    problem_constraint_forward(prob, x_vals);
+    double constrs[2] = {3.0, 8.0};
     problem_jacobian(prob);
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 2));
+    mu_assert("vals fail", cmp_double_array(prob->jacobian->x, Ax, 2));
+    mu_assert("rows fail", cmp_int_array(prob->jacobian->p, Ap, 3));
+    mu_assert("cols fail", cmp_int_array(prob->jacobian->i, Ai, 2));
 
-    double expected_cv[2] = {3.0, 8.0};
-    mu_assert("constraint values wrong (p=[3,4])",
-              cmp_double_array(prob->constraint_values, expected_cv, 2));
-
-    CSR_Matrix *jac = prob->jacobian;
-    mu_assert("jac rows wrong", jac->m == 2);
-    mu_assert("jac cols wrong", jac->n == 2);
-
-    int expected_p[3] = {0, 1, 2};
-    mu_assert("jac->p wrong (p=[3,4])", cmp_int_array(jac->p, expected_p, 3));
-
-    int expected_i[2] = {0, 1};
-    mu_assert("jac->i wrong (p=[3,4])", cmp_int_array(jac->i, expected_i, 2));
-
-    double expected_x[2] = {3.0, 4.0};
-    mu_assert("jac->x wrong (p=[3,4])", cmp_double_array(jac->x, expected_x, 2));
-
-    /* Update p=[5,6] and re-evaluate */
-    double theta2[2] = {5.0, 6.0};
-    problem_update_params(prob, theta2);
-
-    problem_constraint_forward(prob, u);
+    /* test 2: p=[5,6] */
+    theta[0] = 5.0;
+    theta[1] = 6.0;
+    problem_update_params(prob, theta);
+    problem_constraint_forward(prob, x_vals);
     problem_jacobian(prob);
-
-    double expected_cv2[2] = {5.0, 12.0};
-    mu_assert("constraint values wrong (p=[5,6])",
-              cmp_double_array(prob->constraint_values, expected_cv2, 2));
-
-    double expected_x2[2] = {5.0, 6.0};
-    mu_assert("jac->x wrong (p=[5,6])", cmp_double_array(jac->x, expected_x2, 2));
+    constrs[0] = 5.0;
+    constrs[1] = 12.0;
+    Ax[0] = 5.0;
+    Ax[1] = 6.0;
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 2));
+    mu_assert("vals fail", cmp_double_array(prob->jacobian->x, Ax, 2));
+    mu_assert("rows fail", cmp_int_array(prob->jacobian->p, Ap, 3));
+    mu_assert("cols fail", cmp_int_array(prob->jacobian->i, Ai, 2));
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 2));
 
     free_problem(prob);
 
     return 0;
 }
 
-/*
- * Test 3: left_param_matmul in constraint
- *
- * Problem: minimize sum(x), subject to A @ x, x size 2, A is 2x2
- *   A is a 2x2 matrix parameter (param_id=0, size=4, column-major order)
- *   A = [[1,2],[3,4]] → column-major theta = [1,3,2,4]
- *
- * At x=[1,2]:
- *   constraint_values = [1*1+2*2, 3*1+4*2] = [5, 11]
- *   jacobian = [[1,2],[3,4]]
- *
- * After update A = [[5,6],[7,8]] → column-major theta = [5,7,6,8]:
- *   constraint_values = [5*1+6*2, 7*1+8*2] = [17, 23]
- *   jacobian = [[5,6],[7,8]]
- */
 const char *test_param_left_matmul_problem(void)
 {
-    int n_vars = 2;
+    int n = 2;
 
-    /* Objective: sum(x) */
-    expr *x_obj = new_variable(2, 1, 0, n_vars);
-    expr *objective = new_sum(x_obj, -1);
+    /* minimize sum(x) subject to Ax = ?, with A parameter */
+    expr *x = new_variable(2, 1, 0, n);
+    expr *objective = new_sum(x, -1);
+    expr *A_param = new_parameter(2, 2, 0, n, NULL);
 
-    /* Constraint: A @ x */
-    expr *x_con = new_variable(2, 1, 0, n_vars);
-    expr *A_param = new_parameter(2, 2, 0, n_vars, NULL);
-
-    /* Dense 2x2 CSR with placeholder zeros */
-    CSR_Matrix *A = new_csr_matrix(2, 2, 4);
-    int Ap[3] = {0, 2, 4};
-    int Ai[4] = {0, 1, 0, 1};
-    double Ax[4] = {0.0, 0.0, 0.0, 0.0};
-    memcpy(A->p, Ap, 3 * sizeof(int));
-    memcpy(A->i, Ai, 4 * sizeof(int));
-    memcpy(A->x, Ax, 4 * sizeof(double));
-
-    expr *constraint = new_left_matmul(A_param, x_con, A);
-    free_csr_matrix(A);
-
+    /* dense 2x2 matrix */
+    double Ax[4] = {2.0, 0.0, 0.0, 1.0};
+    expr *constraint = new_left_matmul_dense(A_param, x, 2, 2, Ax);
     expr *constraints[1] = {constraint};
-
-    /* Create problem */
     problem *prob = new_problem(objective, constraints, 1, false);
 
+    /* register parameters and fill sparsity patterns*/
     expr *param_nodes[1] = {A_param};
     problem_register_params(prob, param_nodes, 1);
     problem_init_derivatives(prob);
 
-    /* Set A = [[1,2],[3,4]], column-major: [1,3,2,4] */
+    /* point for evaluating and utilities for test */
+    double x_vals[2] = {1.0, 2.0};
+    int Ap[3] = {0, 2, 4};
+    int Ai[4] = {0, 1, 0, 1};
+
+    /* test 1: initial jacobian */
+    problem_constraint_forward(prob, x_vals);
+    double constrs[2] = {2.0, 2.0};
+    problem_jacobian(prob);
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 2));
+    mu_assert("vals fail", cmp_double_array(prob->jacobian->x, Ax, 4));
+    mu_assert("rows fail", cmp_int_array(prob->jacobian->p, Ap, 3));
+    mu_assert("cols fail", cmp_int_array(prob->jacobian->i, Ai, 4));
+
+    /* test 2: A = [[1,2],[3,4]] (column-major [1,3,2,4]) */
     double theta[4] = {1.0, 3.0, 2.0, 4.0};
     problem_update_params(prob, theta);
-
-    double u[2] = {1.0, 2.0};
-    problem_constraint_forward(prob, u);
+    problem_constraint_forward(prob, x_vals);
     problem_jacobian(prob);
-
-    double expected_cv[2] = {5.0, 11.0};
-    mu_assert("constraint values wrong (A1)",
-              cmp_double_array(prob->constraint_values, expected_cv, 2));
-
-    CSR_Matrix *jac = prob->jacobian;
-    mu_assert("jac rows wrong", jac->m == 2);
-    mu_assert("jac cols wrong", jac->n == 2);
-
-    int expected_p[3] = {0, 2, 4};
-    mu_assert("jac->p wrong (A1)", cmp_int_array(jac->p, expected_p, 3));
-
-    int expected_i[4] = {0, 1, 0, 1};
-    mu_assert("jac->i wrong (A1)", cmp_int_array(jac->i, expected_i, 4));
-
-    double expected_x[4] = {1.0, 2.0, 3.0, 4.0};
-    mu_assert("jac->x wrong (A1)", cmp_double_array(jac->x, expected_x, 4));
-
-    /* Update A = [[5,6],[7,8]], column-major: [5,7,6,8] */
-    double theta2[4] = {5.0, 7.0, 6.0, 8.0};
-    problem_update_params(prob, theta2);
-
-    problem_constraint_forward(prob, u);
-    problem_jacobian(prob);
-
-    double expected_cv2[2] = {17.0, 23.0};
-    mu_assert("constraint values wrong (A2)",
-              cmp_double_array(prob->constraint_values, expected_cv2, 2));
-
-    double expected_x2[4] = {5.0, 6.0, 7.0, 8.0};
-    mu_assert("jac->x wrong (A2)", cmp_double_array(jac->x, expected_x2, 4));
+    constrs[0] = 5;
+    constrs[1] = 11;
+    Ax[0] = 1.0;
+    Ax[1] = 2.0;
+    Ax[2] = 3.0;
+    Ax[3] = 4.0;
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 2));
+    mu_assert("vals fail", cmp_double_array(prob->jacobian->x, Ax, 4));
+    mu_assert("rows fail", cmp_int_array(prob->jacobian->p, Ap, 3));
+    mu_assert("cols fail", cmp_int_array(prob->jacobian->i, Ai, 4));
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 2));
 
     free_problem(prob);
 
     return 0;
 }
 
-/*
- * Test 4: right_param_matmul in constraint
- *
- * Problem: minimize sum(x), subject to x @ A, x size 1x2, A is 2x2
- *   A is a 2x2 matrix parameter (param_id=0, size=4, column-major order)
- *   A = [[1,2],[3,4]] → column-major theta = [1,3,2,4]
- *
- * At x=[1,2]:
- *   constraint_values = [1*1+2*3, 1*2+2*4] = [7, 10]
- *   jacobian = [[1,3],[2,4]] = A^T
- *
- * After update A = [[5,6],[7,8]] → column-major theta = [5,7,6,8]:
- *   constraint_values = [1*5+2*7, 1*6+2*8] = [19, 22]
- *   jacobian = [[5,7],[6,8]] = A^T
- */
 const char *test_param_right_matmul_problem(void)
 {
-    int n_vars = 2;
+    int n = 2;
 
-    /* Objective: sum(x) */
-    expr *x_obj = new_variable(1, 2, 0, n_vars);
-    expr *objective = new_sum(x_obj, -1);
+    /* minimize sum(x) subject to xA = ?, with A parameter */
+    expr *x = new_variable(1, 2, 0, n);
+    expr *objective = new_sum(x, -1);
+    expr *A_param = new_parameter(2, 2, 0, n, NULL);
 
-    /* Constraint: x @ A */
-    expr *x_con = new_variable(1, 2, 0, n_vars);
-    expr *A_param = new_parameter(2, 2, 0, n_vars, NULL);
-
-    /* Dense 2x2 CSR with placeholder zeros */
-    CSR_Matrix *A = new_csr_matrix(2, 2, 4);
-    int Ap[3] = {0, 2, 4};
-    int Ai[4] = {0, 1, 0, 1};
-    double Ax[4] = {0.0, 0.0, 0.0, 0.0};
-    memcpy(A->p, Ap, 3 * sizeof(int));
-    memcpy(A->i, Ai, 4 * sizeof(int));
-    memcpy(A->x, Ax, 4 * sizeof(double));
-
-    expr *constraint = new_right_matmul(A_param, x_con, A);
-    free_csr_matrix(A);
-
+    /* dense 2x2 matrix */
+    double Ax[4] = {2.0, 0.0, 0.0, 1.0};
+    expr *constraint = new_right_matmul_dense(A_param, x, 2, 2, Ax);
     expr *constraints[1] = {constraint};
-
-    /* Create problem */
     problem *prob = new_problem(objective, constraints, 1, false);
 
+    /* register parameters and fill sparsity patterns */
     expr *param_nodes[1] = {A_param};
     problem_register_params(prob, param_nodes, 1);
     problem_init_derivatives(prob);
 
-    /* Set A = [[1,2],[3,4]], column-major: [1,3,2,4] */
+    /* point for evaluating and utilities for test */
+    double x_vals[2] = {1.0, 2.0};
+    int Ap[3] = {0, 2, 4};
+    int Ai[4] = {0, 1, 0, 1};
+
+    /* test 1: initial jacobian */
+    problem_constraint_forward(prob, x_vals);
+    double constrs[2] = {2.0, 2.0};
+    problem_jacobian(prob);
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 2));
+    mu_assert("vals fail", cmp_double_array(prob->jacobian->x, Ax, 4));
+    mu_assert("rows fail", cmp_int_array(prob->jacobian->p, Ap, 3));
+    mu_assert("cols fail", cmp_int_array(prob->jacobian->i, Ai, 4));
+
+    /* test 2: A = [[1,2],[3,4]] (column-major [1,3,2,4]) */
     double theta[4] = {1.0, 3.0, 2.0, 4.0};
     problem_update_params(prob, theta);
-
-    double u[2] = {1.0, 2.0};
-    problem_constraint_forward(prob, u);
+    problem_constraint_forward(prob, x_vals);
     problem_jacobian(prob);
-
-    double expected_cv[2] = {7.0, 10.0};
-    mu_assert("constraint values wrong (A1)",
-              cmp_double_array(prob->constraint_values, expected_cv, 2));
-
-    CSR_Matrix *jac = prob->jacobian;
-    mu_assert("jac rows wrong", jac->m == 2);
-    mu_assert("jac cols wrong", jac->n == 2);
-
-    int expected_p[3] = {0, 2, 4};
-    mu_assert("jac->p wrong (A1)", cmp_int_array(jac->p, expected_p, 3));
-
-    int expected_i[4] = {0, 1, 0, 1};
-    mu_assert("jac->i wrong (A1)", cmp_int_array(jac->i, expected_i, 4));
-
-    double expected_x[4] = {1.0, 3.0, 2.0, 4.0};
-    mu_assert("jac->x wrong (A1)", cmp_double_array(jac->x, expected_x, 4));
-
-    /* Update A = [[5,6],[7,8]], column-major: [5,7,6,8] */
-    double theta2[4] = {5.0, 7.0, 6.0, 8.0};
-    problem_update_params(prob, theta2);
-
-    problem_constraint_forward(prob, u);
-    problem_jacobian(prob);
-
-    double expected_cv2[2] = {19.0, 22.0};
-    mu_assert("constraint values wrong (A2)",
-              cmp_double_array(prob->constraint_values, expected_cv2, 2));
-
-    double expected_x2[4] = {5.0, 7.0, 6.0, 8.0};
-    mu_assert("jac->x wrong (A2)", cmp_double_array(jac->x, expected_x2, 4));
+    constrs[0] = 7;
+    constrs[1] = 10;
+    Ax[0] = 1.0;
+    Ax[1] = 3.0;
+    Ax[2] = 2.0;
+    Ax[3] = 4.0;
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 2));
+    mu_assert("vals fail", cmp_double_array(prob->jacobian->x, Ax, 4));
+    mu_assert("rows fail", cmp_int_array(prob->jacobian->p, Ap, 3));
+    mu_assert("cols fail", cmp_int_array(prob->jacobian->i, Ai, 4));
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 2));
 
     free_problem(prob);
 
     return 0;
 }
 
-/*
- * Test 5: PARAM_FIXED params are skipped by problem_update_params
- *
- * Problem: minimize a * sum(log(x)) + b * sum(x), no constraints, x size 2
- *   a is a FIXED scalar parameter (param_id=PARAM_FIXED, value=2.0)
- *   b is an updatable scalar parameter (param_id=0)
- *
- * At x=[1,2], a=2, b=3:
- *   obj = 2*(log(1)+log(2)) + 3*(1+2) = 2*log(2) + 9
- *   gradient = [2/1 + 3, 2/2 + 3] = [5.0, 4.0]
- *
- * After update theta={5.0} (only b changes to 5, a stays 2):
- *   obj = 2*log(2) + 5*3 = 2*log(2) + 15
- *   gradient = [2/1 + 5, 2/2 + 5] = [7.0, 6.0]
- */
 const char *test_param_fixed_skip_in_update(void)
 {
-    int n_vars = 2;
+    int n = 2;
 
-    /* Build tree: a * sum(log(x)) + b * sum(x) */
-    expr *x1 = new_variable(2, 1, 0, n_vars);
-    expr *log_x = new_log(x1);
+    /* minimize a * sum(log(x)) + b * sum(x), a fixed, b updatable */
+    expr *x = new_variable(2, 1, 0, n);
+    expr *log_x = new_log(x);
     double a_val = 2.0;
-    expr *a_param = new_parameter(1, 1, PARAM_FIXED, n_vars, &a_val);
+    expr *a_param = new_parameter(1, 1, PARAM_FIXED, n, &a_val);
     expr *a_log = new_scalar_mult(a_param, log_x);
     expr *sum_a_log = new_sum(a_log, -1);
 
-    expr *x2 = new_variable(2, 1, 0, n_vars);
-    expr *b_param = new_parameter(1, 1, 0, n_vars, NULL);
-    expr *b_x = new_scalar_mult(b_param, x2);
+    expr *b_param = new_parameter(1, 1, 0, n, NULL);
+    expr *b_x = new_scalar_mult(b_param, x);
     expr *sum_b_x = new_sum(b_x, -1);
 
     expr *objective = new_add(sum_a_log, sum_b_x);
-
-    /* Create problem and register BOTH params */
     problem *prob = new_problem(objective, NULL, 0, false);
 
+    /* register parameters and fill sparsity patterns */
     expr *param_nodes[2] = {a_param, b_param};
     problem_register_params(prob, param_nodes, 2);
     problem_init_derivatives(prob);
 
-    /* Set b=3 and evaluate at x=[1,2] */
+    /* point for evaluating */
+    double x_vals[2] = {1.0, 2.0};
+
+    /* test 1: b=3, a stays 2 */
     double theta[1] = {3.0};
     problem_update_params(prob, theta);
-
-    /* Verify a is still 2.0 (not overwritten) */
-    mu_assert("a_param changed after update", fabs(a_param->value[0] - 2.0) < 1e-10);
-
-    double u[2] = {1.0, 2.0};
-    double obj_val = problem_objective_forward(prob, u);
+    mu_assert("vals fail", fabs(a_param->value[0] - 2.0) < 1e-10);
+    double obj_val = problem_objective_forward(prob, x_vals);
     problem_gradient(prob);
-
     double expected_obj = 2.0 * log(2.0) + 9.0;
-    mu_assert("obj wrong (b=3)", fabs(obj_val - expected_obj) < 1e-10);
+    mu_assert("vals fail", fabs(obj_val - expected_obj) < 1e-10);
+    double grad[2] = {5.0, 4.0};
+    mu_assert("vals fail", cmp_double_array(prob->gradient_values, grad, 2));
 
-    double expected_grad[2] = {5.0, 4.0};
-    mu_assert("gradient wrong (b=3)",
-              cmp_double_array(prob->gradient_values, expected_grad, 2));
-
-    /* Update b=5, a should stay 2 */
+    /* test 2: b=5, a stays 2 */
     theta[0] = 5.0;
     problem_update_params(prob, theta);
-
-    mu_assert("a_param changed after second update",
-              fabs(a_param->value[0] - 2.0) < 1e-10);
-
-    obj_val = problem_objective_forward(prob, u);
+    mu_assert("vals fail", fabs(a_param->value[0] - 2.0) < 1e-10);
+    obj_val = problem_objective_forward(prob, x_vals);
     problem_gradient(prob);
-
-    double expected_obj2 = 2.0 * log(2.0) + 15.0;
-    mu_assert("obj wrong (b=5)", fabs(obj_val - expected_obj2) < 1e-10);
-
-    double expected_grad2[2] = {7.0, 6.0};
-    mu_assert("gradient wrong (b=5)",
-              cmp_double_array(prob->gradient_values, expected_grad2, 2));
+    expected_obj = 2.0 * log(2.0) + 15.0;
+    mu_assert("vals fail", fabs(obj_val - expected_obj) < 1e-10);
+    grad[0] = 7.0;
+    grad[1] = 6.0;
+    mu_assert("vals fail", cmp_double_array(prob->gradient_values, grad, 2));
 
     free_problem(prob);
 
     return 0;
 }
 
-/*
- * Test 6: left_param_matmul with rectangular 3x2 matrix
- *
- * Problem: minimize sum(x), subject to A @ x, x size 2, A is 3x2
- *   A = [[1,2],[3,4],[5,6]] → column-major theta = [1,3,5,2,4,6]
- *
- * At x=[1,2]:
- *   constraint_values = [1+4, 3+8, 5+12] = [5, 11, 17]
- *   jacobian = [[1,2],[3,4],[5,6]]
- */
 const char *test_param_left_matmul_rectangular(void)
 {
-    int n_vars = 2;
+    int n = 2;
 
-    /* Objective: sum(x) */
-    expr *x_obj = new_variable(2, 1, 0, n_vars);
-    expr *objective = new_sum(x_obj, -1);
+    /* minimize sum(x) subject to Ax = ?, with A parameter (3x2) */
+    expr *x = new_variable(2, 1, 0, n);
+    expr *objective = new_sum(x, -1);
+    expr *A_param = new_parameter(3, 2, 0, n, NULL);
 
-    /* Constraint: A @ x, A is 3x2 */
-    expr *x_con = new_variable(2, 1, 0, n_vars);
-    expr *A_param = new_parameter(3, 2, 0, n_vars, NULL);
+    /* dense 3x2 matrix */
+    double Ax[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    expr *constraint = new_left_matmul_dense(A_param, x, 3, 2, Ax);
+    expr *constraints[1] = {constraint};
+    problem *prob = new_problem(objective, constraints, 1, false);
 
-    /* Dense 3x2 CSR */
-    CSR_Matrix *A = new_csr_matrix(3, 2, 6);
+    /* register parameters and fill sparsity patterns */
+    expr *param_nodes[1] = {A_param};
+    problem_register_params(prob, param_nodes, 1);
+    problem_init_derivatives(prob);
+
+    /* point for evaluating and utilities for test */
+    double x_vals[2] = {1.0, 2.0};
     int Ap[4] = {0, 2, 4, 6};
     int Ai[6] = {0, 1, 0, 1, 0, 1};
-    double Ax[6] = {0, 0, 0, 0, 0, 0};
-    memcpy(A->p, Ap, 4 * sizeof(int));
-    memcpy(A->i, Ai, 6 * sizeof(int));
-    memcpy(A->x, Ax, 6 * sizeof(double));
 
-    expr *constraint = new_left_matmul(A_param, x_con, A);
-    free_csr_matrix(A);
-
-    expr *constraints[1] = {constraint};
-
-    problem *prob = new_problem(objective, constraints, 1, false);
-
-    expr *param_nodes[1] = {A_param};
-    problem_register_params(prob, param_nodes, 1);
-    problem_init_derivatives(prob);
-
-    /* Set A = [[1,2],[3,4],[5,6]], column-major: [1,3,5,2,4,6] */
-    double theta[6] = {1.0, 3.0, 5.0, 2.0, 4.0, 6.0};
-    problem_update_params(prob, theta);
-
-    double u[2] = {1.0, 2.0};
-    problem_constraint_forward(prob, u);
+    /* test 1: initial jacobian */
+    problem_constraint_forward(prob, x_vals);
+    double constrs[3] = {5.0, 11.0, 17.0};
     problem_jacobian(prob);
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 3));
+    mu_assert("vals fail", cmp_double_array(prob->jacobian->x, Ax, 6));
+    mu_assert("rows fail", cmp_int_array(prob->jacobian->p, Ap, 4));
+    mu_assert("cols fail", cmp_int_array(prob->jacobian->i, Ai, 6));
 
-    double expected_cv[3] = {5.0, 11.0, 17.0};
-    mu_assert("rect constraint values wrong",
-              cmp_double_array(prob->constraint_values, expected_cv, 3));
-
-    CSR_Matrix *jac = prob->jacobian;
-    double expected_x[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
-    mu_assert("rect jac->x wrong", cmp_double_array(jac->x, expected_x, 6));
-
-    free_problem(prob);
-
-    return 0;
-}
-
-/*
- * Test 7: left_param_matmul with sparse matrix (structural zeros)
- *
- * Problem: minimize sum(x), subject to A @ x, x size 3, A is 3x3 sparse
- *   A = [[1, 0, 2],
- *        [0, 3, 0],
- *        [4, 0, 5]]
- *   CSR: p=[0,2,3,5], i=[0,2, 1, 0,2], nnz=5
- *   Column-major theta (full 9 values): [1,0,4, 0,3,0, 2,0,5]
- *
- * At x=[1,2,3]:
- *   constraint_values = [1+6, 6, 4+15] = [7, 6, 19]
- *   jacobian = A
- */
-const char *test_param_left_matmul_sparse(void)
-{
-    int n_vars = 3;
-
-    /* Objective: sum(x) */
-    expr *x_obj = new_variable(3, 1, 0, n_vars);
-    expr *objective = new_sum(x_obj, -1);
-
-    /* Constraint: A @ x, A is 3x3 sparse */
-    expr *x_con = new_variable(3, 1, 0, n_vars);
-    expr *A_param = new_parameter(3, 3, 0, n_vars, NULL);
-
-    CSR_Matrix *A = new_csr_matrix(3, 3, 5);
-    int Ap[4] = {0, 2, 3, 5};
-    int Ai[5] = {0, 2, 1, 0, 2};
-    double Ax[5] = {0, 0, 0, 0, 0};
-    memcpy(A->p, Ap, 4 * sizeof(int));
-    memcpy(A->i, Ai, 5 * sizeof(int));
-    memcpy(A->x, Ax, 5 * sizeof(double));
-
-    expr *constraint = new_left_matmul(A_param, x_con, A);
-    free_csr_matrix(A);
-
-    expr *constraints[1] = {constraint};
-
-    problem *prob = new_problem(objective, constraints, 1, false);
-
-    expr *param_nodes[1] = {A_param};
-    problem_register_params(prob, param_nodes, 1);
-    problem_init_derivatives(prob);
-
-    /* A = [[1,0,2],[0,3,0],[4,0,5]], column-major: [1,0,4, 0,3,0, 2,0,5] */
-    double theta[9] = {1.0, 0.0, 4.0, 0.0, 3.0, 0.0, 2.0, 0.0, 5.0};
+    /* test 2: A = [[7,8],[9,10],[11,12]] (column-major [7,9,11,8,10,12]) */
+    double theta[6] = {7.0, 9.0, 11.0, 8.0, 10.0, 12.0};
     problem_update_params(prob, theta);
-
-    double u[3] = {1.0, 2.0, 3.0};
-    problem_constraint_forward(prob, u);
+    problem_constraint_forward(prob, x_vals);
     problem_jacobian(prob);
-
-    double expected_cv[3] = {7.0, 6.0, 19.0};
-    mu_assert("sparse constraint values wrong",
-              cmp_double_array(prob->constraint_values, expected_cv, 3));
-
-    CSR_Matrix *jac = prob->jacobian;
-    mu_assert("sparse jac nnz wrong", jac->nnz == 5);
-
-    /* CSR data order: row0=[1,2], row1=[3], row2=[4,5] */
-    double expected_x[5] = {1.0, 2.0, 3.0, 4.0, 5.0};
-    mu_assert("sparse jac->x wrong", cmp_double_array(jac->x, expected_x, 5));
+    constrs[0] = 23.0;
+    constrs[1] = 29.0;
+    constrs[2] = 35.0;
+    Ax[0] = 7.0;
+    Ax[1] = 8.0;
+    Ax[2] = 9.0;
+    Ax[3] = 10.0;
+    Ax[4] = 11.0;
+    Ax[5] = 12.0;
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 3));
+    mu_assert("vals fail", cmp_double_array(prob->jacobian->x, Ax, 6));
+    mu_assert("rows fail", cmp_int_array(prob->jacobian->p, Ap, 4));
+    mu_assert("cols fail", cmp_int_array(prob->jacobian->i, Ai, 6));
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 3));
 
     free_problem(prob);
 


### PR DESCRIPTION
CVXPY sends parameter values in Fortran (column-major) order, but the matmul refresh functions assumed row-major/CSR order via raw memcpy. This produced incorrect matrix values for non-symmetric matrices.

For sparse matrices, iterate the CSR pattern and index into the column-major source array. For dense matrices, exploit the fact that column-major A is row-major A^T to memcpy directly into AT, then transpose to get A.

Also fixes a latent bug where sparse update_values would blindly copy the first nnz values from the full d1*d2 parameter array, which is wrong for matrices with structural zeros.

Adds tests for rectangular (3x2) and sparse (3x3 with zeros) cases.