### PR TITLE
Adds thread-safety for trees that are accessed on only one thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 project(DNLP_Diff_Engine C)
-set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD 11)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(DIFF_ENGINE_VERSION_MAJOR 0)

--- a/include/utils/tracked_alloc.h
+++ b/include/utils/tracked_alloc.h
@@ -34,8 +34,8 @@
 #define TRACKED_BLOCK_SIZE(p) malloc_usable_size(p)
 #endif
 
-extern size_t g_allocated_bytes; /* current live bytes */
-extern size_t g_peak_bytes;      /* high-water mark since last reset */
+extern _Thread_local size_t g_allocated_bytes; /* current live bytes */
+extern _Thread_local size_t g_peak_bytes;      /* high-water mark since last reset */
 
 /* All allocations in src/ must go through these wrappers (and pair sp_free
    with sp_malloc / sp_calloc). Tests may use plain malloc/free — those

--- a/src/utils/tracked_alloc.c
+++ b/src/utils/tracked_alloc.c
@@ -17,5 +17,5 @@
  */
 #include "utils/tracked_alloc.h"
 
-size_t g_allocated_bytes = 0;
-size_t g_peak_bytes = 0;
+_Thread_local size_t g_allocated_bytes = 0;
+_Thread_local size_t g_peak_bytes = 0;


### PR DESCRIPTION
Best I can tell from going through the code, the only state that is shared across trees is the alloc variables; so this makes them thread locals.

To access thread locals, I bump the C version to C11. Every platform CVXPY supports supports C11, so I figured this would be not an issue. LMK if I am worng.