### PR TITLE
Make sparsity fills output-driven in block left-multiply and csr@csc matmul

### DIFF
--- a/src/utils/linalg_sparse_matmuls.c
+++ b/src/utils/linalg_sparse_matmuls.c
@@ -101,6 +101,20 @@ CSC_matrix *block_left_multiply_fill_sparsity(const CSR_matrix *A,
     iVec *Ci = iVec_new(J->nnz > 0 ? J->nnz : 1);
     Cp[0] = 0;
 
+    /* Output-driven gather: row i of A intersects a block's child entries iff
+       i appears in A's CSC column list of one of those entries, so walk only
+       those columns instead of testing all m rows per (column, block). A CSC
+       view of A is built once; candidates are deduped with a generation-stamp
+       workspace and sorted to reproduce the ascending row order the old
+       has_overlap row scan emitted. */
+    int *iwork = (int *) sp_malloc((n > 0 ? n : 1) * sizeof(int));
+    CSC_matrix *A_csc = csr_to_csc_alloc(A, iwork);
+    sp_free(iwork);
+
+    int *stamp = (int *) sp_calloc(m > 0 ? m : 1, sizeof(int)); /* 0 = unseen */
+    int *cand = (int *) sp_malloc((m > 0 ? m : 1) * sizeof(int));
+    int gen = 0;
+
     /* for each column of J */
     for (j = 0; j < J->n; j++)
     {
@@ -134,29 +148,44 @@ CSC_matrix *block_left_multiply_fill_sparsity(const CSR_matrix *A,
             }
 
             block_jj_end = jj;
-            int nnz_in_block = block_jj_end - block_jj_start;
-            if (nnz_in_block == 0)
+            if (block_jj_end == block_jj_start)
             {
                 continue;
             }
 
             // -----------------------------------------------------------------
-            // check which rows of A overlap with the column indices of J in this
-            // block
+            // gather the rows of A that hit this block's child entries via the
+            // CSC columns of A, dedup with the generation stamp, sort ascending
             // -----------------------------------------------------------------
-            row_offset = block * m;
-            for (int i = 0; i < A->m; i++)
+            gen++;
+            int n_cand = 0;
+            for (int t = block_jj_start; t < block_jj_end; t++)
             {
-                int a_len = A->p[i + 1] - A->p[i];
-                if (has_overlap(A->i + A->p[i], a_len, J->i + block_jj_start,
-                                nnz_in_block, block_start))
+                int c = J->i[t] - block_start; /* column of A */
+                for (int q = A_csc->p[c]; q < A_csc->p[c + 1]; q++)
                 {
-                    iVec_append(Ci, row_offset + i);
+                    int i = A_csc->i[q];
+                    if (stamp[i] != gen)
+                    {
+                        stamp[i] = gen;
+                        cand[n_cand++] = i;
+                    }
                 }
+            }
+
+            sort_int_array(cand, n_cand);
+            row_offset = block * m;
+            for (int t = 0; t < n_cand; t++)
+            {
+                iVec_append(Ci, row_offset + cand[t]);
             }
         }
         Cp[j + 1] = Ci->len;
     }
+
+    free_CSC_matrix(A_csc);
+    sp_free(stamp);
+    sp_free(cand);
 
     CSC_matrix *C = new_CSC_matrix(m * p, J->n, Ci->len);
     memcpy(C->p, Cp, (J->n + 1) * sizeof(int));
@@ -258,12 +287,24 @@ CSR_matrix *csr_csc_matmul_alloc(const CSR_matrix *A, const CSC_matrix *B)
     int m = A->m;
     int p = B->n;
 
-    int len_a, len_b;
-
     int *Cp = (int *) sp_malloc((m + 1) * sizeof(int));
     iVec *Ci = iVec_new(m);
 
     Cp[0] = 0;
+
+    /* Output-driven gather: column j of B intersects row i of A iff j appears
+       in B's CSR row list of one of A's row-i column indices, so walk only
+       those rows of B instead of testing all p columns per row of A. A CSR
+       view of B is built once; candidates are deduped with a generation-stamp
+       workspace and sorted to reproduce the ascending column order the old
+       has_overlap column scan emitted. */
+    int *iwork = (int *) sp_malloc((B->m > 0 ? B->m : 1) * sizeof(int));
+    CSR_matrix *B_csr = csc_to_csr_alloc(B, iwork);
+    sp_free(iwork);
+
+    int *stamp = (int *) sp_calloc(p > 0 ? p : 1, sizeof(int)); /* 0 = unseen */
+    int *cand = (int *) sp_malloc((p > 0 ? p : 1) * sizeof(int));
+    int gen = 0;
 
     // --------------------------------------------------------------
     //            count nnz and fill column indices
@@ -271,21 +312,35 @@ CSR_matrix *csr_csc_matmul_alloc(const CSR_matrix *A, const CSC_matrix *B)
     int nnz = 0;
     for (int i = 0; i < A->m; i++)
     {
-        len_a = A->p[i + 1] - A->p[i];
-
-        for (int j = 0; j < B->n; j++)
+        gen++;
+        int n_cand = 0;
+        for (int t = A->p[i]; t < A->p[i + 1]; t++)
         {
-            len_b = B->p[j + 1] - B->p[j];
-
-            if (has_overlap(A->i + A->p[i], len_a, B->i + B->p[j], len_b, 0))
+            int k = A->i[t]; /* row of B */
+            for (int q = B_csr->p[k]; q < B_csr->p[k + 1]; q++)
             {
-                iVec_append(Ci, j);
-                nnz++;
+                int j = B_csr->i[q];
+                if (stamp[j] != gen)
+                {
+                    stamp[j] = gen;
+                    cand[n_cand++] = j;
+                }
             }
         }
 
+        sort_int_array(cand, n_cand);
+        for (int t = 0; t < n_cand; t++)
+        {
+            iVec_append(Ci, cand[t]);
+        }
+        nnz += n_cand;
+
         Cp[i + 1] = nnz;
     }
+
+    free_CSR_matrix(B_csr);
+    sp_free(stamp);
+    sp_free(cand);
 
     CSR_matrix *C = new_CSR_matrix(m, p, nnz);
     memcpy(C->p, Cp, (m + 1) * sizeof(int));

--- a/src/utils/linalg_sparse_matmuls.c
+++ b/src/utils/linalg_sparse_matmuls.c
@@ -86,6 +86,35 @@ static inline double sparse_dot_offset(const double *a_x, const int *a_idx,
     return sum;
 }
 
+/* Symbolic phase of Gustavson's sparse matmul: an output row's (or column's)
+   sparsity pattern is the union of the operand index lists selected by keys,
+   i.e. the lists list_i[list_p[k] .. list_p[k+1]] for each k = keys[t] -
+   key_offset. Compute that union into cand, deduplicated with a
+   generation-stamped workspace and sorted ascending (the order the downstream
+   sparse dot products require). Returns the number of gathered indices. */
+static int sorted_pattern_union(const int *keys, int n_keys, int key_offset,
+                                const int *list_p, const int *list_i, int *stamp,
+                                int *cand, int *gen)
+{
+    int g = ++(*gen);
+    int n_cand = 0;
+    for (int t = 0; t < n_keys; t++)
+    {
+        int k = keys[t] - key_offset;
+        for (int q = list_p[k]; q < list_p[k + 1]; q++)
+        {
+            int i = list_i[q];
+            if (stamp[i] != g)
+            {
+                stamp[i] = g;
+                cand[n_cand++] = i;
+            }
+        }
+    }
+    sort_int_array(cand, n_cand);
+    return n_cand;
+}
+
 CSC_matrix *block_left_multiply_fill_sparsity(const CSR_matrix *A,
                                               const CSC_matrix *J, int p)
 {
@@ -101,12 +130,9 @@ CSC_matrix *block_left_multiply_fill_sparsity(const CSR_matrix *A,
     iVec *Ci = iVec_new(J->nnz > 0 ? J->nnz : 1);
     Cp[0] = 0;
 
-    /* Output-driven gather: row i of A intersects a block's child entries iff
-       i appears in A's CSC column list of one of those entries, so walk only
-       those columns instead of testing all m rows per (column, block). A CSC
-       view of A is built once; candidates are deduped with a generation-stamp
-       workspace and sorted to reproduce the ascending row order the old
-       has_overlap row scan emitted. */
+    /* Output-driven: row i of A intersects a block's child entries iff i
+       appears in the CSC column list of one of those entries, so gather those
+       columns instead of testing all m rows per (column, block). */
     int *iwork = (int *) sp_malloc((n > 0 ? n : 1) * sizeof(int));
     CSC_matrix *A_csc = csr_to_csc_alloc(A, iwork);
     sp_free(iwork);
@@ -154,26 +180,11 @@ CSC_matrix *block_left_multiply_fill_sparsity(const CSR_matrix *A,
             }
 
             // -----------------------------------------------------------------
-            // gather the rows of A that hit this block's child entries via the
-            // CSC columns of A, dedup with the generation stamp, sort ascending
+            // gather the rows of A that hit this block's child entries
             // -----------------------------------------------------------------
-            gen++;
-            int n_cand = 0;
-            for (int t = block_jj_start; t < block_jj_end; t++)
-            {
-                int c = J->i[t] - block_start; /* column of A */
-                for (int q = A_csc->p[c]; q < A_csc->p[c + 1]; q++)
-                {
-                    int i = A_csc->i[q];
-                    if (stamp[i] != gen)
-                    {
-                        stamp[i] = gen;
-                        cand[n_cand++] = i;
-                    }
-                }
-            }
-
-            sort_int_array(cand, n_cand);
+            int n_cand = sorted_pattern_union(
+                J->i + block_jj_start, block_jj_end - block_jj_start, block_start,
+                A_csc->p, A_csc->i, stamp, cand, &gen);
             row_offset = block * m;
             for (int t = 0; t < n_cand; t++)
             {
@@ -292,12 +303,9 @@ CSR_matrix *csr_csc_matmul_alloc(const CSR_matrix *A, const CSC_matrix *B)
 
     Cp[0] = 0;
 
-    /* Output-driven gather: column j of B intersects row i of A iff j appears
-       in B's CSR row list of one of A's row-i column indices, so walk only
-       those rows of B instead of testing all p columns per row of A. A CSR
-       view of B is built once; candidates are deduped with a generation-stamp
-       workspace and sorted to reproduce the ascending column order the old
-       has_overlap column scan emitted. */
+    /* Output-driven: column j of B intersects row i of A iff j appears in the
+       CSR row list of one of A's row-i column indices, so gather those rows
+       instead of testing all p columns per row of A. */
     int *iwork = (int *) sp_malloc((B->m > 0 ? B->m : 1) * sizeof(int));
     CSR_matrix *B_csr = csc_to_csr_alloc(B, iwork);
     sp_free(iwork);
@@ -312,23 +320,8 @@ CSR_matrix *csr_csc_matmul_alloc(const CSR_matrix *A, const CSC_matrix *B)
     int nnz = 0;
     for (int i = 0; i < A->m; i++)
     {
-        gen++;
-        int n_cand = 0;
-        for (int t = A->p[i]; t < A->p[i + 1]; t++)
-        {
-            int k = A->i[t]; /* row of B */
-            for (int q = B_csr->p[k]; q < B_csr->p[k + 1]; q++)
-            {
-                int j = B_csr->i[q];
-                if (stamp[j] != gen)
-                {
-                    stamp[j] = gen;
-                    cand[n_cand++] = j;
-                }
-            }
-        }
-
-        sort_int_array(cand, n_cand);
+        int n_cand = sorted_pattern_union(A->i + A->p[i], A->p[i + 1] - A->p[i], 0,
+                                          B_csr->p, B_csr->i, stamp, cand, &gen);
         for (int t = 0; t < n_cand; t++)
         {
             iVec_append(Ci, cand[t]);

--- a/tests/all_tests.c
+++ b/tests/all_tests.c
@@ -368,8 +368,12 @@ int main(void)
     mu_run_test(test_block_left_multiply_single_block, tests_run);
     mu_run_test(test_block_left_multiply_two_blocks, tests_run);
     mu_run_test(test_block_left_multiply_zero_column, tests_run);
+    mu_run_test(test_block_left_multiply_dedup_order, tests_run);
+    mu_run_test(test_block_left_multiply_matches_reference_random, tests_run);
     mu_run_test(test_csr_csc_matmul_alloc_basic, tests_run);
     mu_run_test(test_csr_csc_matmul_alloc_sparse, tests_run);
+    mu_run_test(test_csr_csc_matmul_alloc_dedup_order, tests_run);
+    mu_run_test(test_csr_csc_matmul_alloc_matches_reference_random, tests_run);
     mu_run_test(test_block_left_multiply_vec_single_block, tests_run);
     mu_run_test(test_block_left_multiply_vec_two_blocks, tests_run);
     mu_run_test(test_block_left_multiply_vec_sparse, tests_run);

--- a/tests/utils/test_linalg_sparse_matmuls.h
+++ b/tests/utils/test_linalg_sparse_matmuls.h
@@ -333,17 +333,28 @@ static CSC_matrix *block_left_multiply_fill_sparsity_ref(const CSR_matrix *A,
         {
             int block_start = block * n;
             int block_end = block_start + n;
-            while (jj < J->p[j + 1] && J->i[jj] < block_start) jj++;
+            while (jj < J->p[j + 1] && J->i[jj] < block_start)
+            {
+                jj++;
+            }
             int block_jj_start = jj;
-            while (jj < J->p[j + 1] && J->i[jj] < block_end) jj++;
+            while (jj < J->p[j + 1] && J->i[jj] < block_end)
+            {
+                jj++;
+            }
             int nnz_in_block = jj - block_jj_start;
-            if (nnz_in_block == 0) continue;
+            if (nnz_in_block == 0)
+            {
+                continue;
+            }
             for (int i = 0; i < m; i++)
             {
                 int a_len = A->p[i + 1] - A->p[i];
                 if (has_overlap(A->i + A->p[i], a_len, J->i + block_jj_start,
                                 nnz_in_block, block_start))
+                {
                     iVec_append(Ci, block * m + i);
+                }
             }
         }
         Cp[j + 1] = Ci->len;
@@ -363,16 +374,13 @@ const char *test_block_left_multiply_matches_reference_random(void)
 {
     srand(42);
     int n = 15, p = 3, k = 8;
-    int iwork_size;
 
     for (int trial = 0; trial < 5; trial++)
     {
         CSR_matrix *A = new_csr_random(20, n, 0.2);
         CSR_matrix *G = new_csr_random(n * p, k, 0.15);
 
-        iwork_size = G->n;
-        int *iwork =
-            (int *) sp_malloc((iwork_size > 0 ? iwork_size : 1) * sizeof(int));
+        int *iwork = (int *) sp_malloc(G->n * sizeof(int));
         CSC_matrix *J = csr_to_csc_alloc(G, iwork);
         sp_free(iwork);
 

--- a/tests/utils/test_linalg_sparse_matmuls.h
+++ b/tests/utils/test_linalg_sparse_matmuls.h
@@ -7,7 +7,10 @@
 #include "test_helpers.h"
 #include "utils/CSC_matrix.h"
 #include "utils/CSR_matrix.h"
+#include "utils/iVec.h"
 #include "utils/linalg_sparse_matmuls.h"
+#include "utils/tracked_alloc.h"
+#include "utils/utils.h"
 
 /* Test block_left_multiply_fill_sparsity with simple case: single block */
 const char *test_block_left_multiply_single_block(void)
@@ -258,6 +261,246 @@ const char *test_csr_csc_matmul_alloc_sparse(void)
     free_CSR_matrix(C);
     free_CSR_matrix(A);
     free_CSC_matrix(B);
+    return NULL;
+}
+
+/* Dedup + ordering: one block whose child entries hit the same A row through
+ * several columns (dedup), with CSC column lists that interleave so a missing
+ * sort would emit rows out of ascending order. */
+const char *test_block_left_multiply_dedup_order(void)
+{
+    /* A is 4x3 CSR_matrix:
+     * [1.0  0.0  2.0]     CSC col 0: rows {0, 2}
+     * [0.0  3.0  0.0]     CSC col 1: rows {1, 3}
+     * [4.0  0.0  0.0]     CSC col 2: rows {0, 3}
+     * [0.0  5.0  6.0]
+     */
+    CSR_matrix *A = new_CSR_matrix(4, 3, 6);
+    double Ax[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+    int Ai[6] = {0, 2, 1, 0, 1, 2};
+    int Ap[5] = {0, 2, 3, 4, 6};
+    memcpy(A->x, Ax, 6 * sizeof(double));
+    memcpy(A->i, Ai, 6 * sizeof(int));
+    memcpy(A->p, Ap, 5 * sizeof(int));
+
+    /* J is 3x1 dense column (p=1): child entries 0, 1, 2. Gathering CSC columns
+     * in child order visits rows 0,2 then 1,3 then 0,3 — rows 0 and 3 twice
+     * (dedup) and out of order (sort). Expected: all four rows, ascending. */
+    CSC_matrix *J = new_CSC_matrix(3, 1, 3);
+    double Jx[3] = {1.0, 1.0, 1.0};
+    int Ji[3] = {0, 1, 2};
+    int Jp[2] = {0, 3};
+    memcpy(J->x, Jx, 3 * sizeof(double));
+    memcpy(J->i, Ji, 3 * sizeof(int));
+    memcpy(J->p, Jp, 2 * sizeof(int));
+
+    CSC_matrix *C = block_left_multiply_fill_sparsity(A, J, 1);
+
+    int expected_p[2] = {0, 4};
+    int expected_i[4] = {0, 1, 2, 3};
+
+    mu_assert("C dims incorrect", C->m == 4 && C->n == 1 && C->nnz == 4);
+    mu_assert("C col pointers incorrect", cmp_int_array(C->p, expected_p, 2));
+    mu_assert("C row indices incorrect", cmp_int_array(C->i, expected_i, 4));
+
+    free_CSC_matrix(C);
+    free_CSR_matrix(A);
+    free_CSC_matrix(J);
+    return NULL;
+}
+
+/* Reference implementation of the block sparsity (the original per-row
+ * has_overlap scan) used to cross-check the gather rewrite on random input. */
+static CSC_matrix *block_left_multiply_fill_sparsity_ref(const CSR_matrix *A,
+                                                         const CSC_matrix *J, int p)
+{
+    int m = A->m;
+    int n = A->n;
+
+    int *Cp = (int *) sp_malloc((J->n + 1) * sizeof(int));
+    iVec *Ci = iVec_new(J->nnz > 0 ? J->nnz : 1);
+    Cp[0] = 0;
+
+    for (int j = 0; j < J->n; j++)
+    {
+        if (J->p[j] == J->p[j + 1])
+        {
+            Cp[j + 1] = Cp[j];
+            continue;
+        }
+        int jj = J->p[j];
+        for (int block = 0; block < p; block++)
+        {
+            int block_start = block * n;
+            int block_end = block_start + n;
+            while (jj < J->p[j + 1] && J->i[jj] < block_start) jj++;
+            int block_jj_start = jj;
+            while (jj < J->p[j + 1] && J->i[jj] < block_end) jj++;
+            int nnz_in_block = jj - block_jj_start;
+            if (nnz_in_block == 0) continue;
+            for (int i = 0; i < m; i++)
+            {
+                int a_len = A->p[i + 1] - A->p[i];
+                if (has_overlap(A->i + A->p[i], a_len, J->i + block_jj_start,
+                                nnz_in_block, block_start))
+                    iVec_append(Ci, block * m + i);
+            }
+        }
+        Cp[j + 1] = Ci->len;
+    }
+
+    CSC_matrix *C = new_CSC_matrix(m * p, J->n, Ci->len);
+    memcpy(C->p, Cp, (J->n + 1) * sizeof(int));
+    memcpy(C->i, Ci->data, Ci->len * sizeof(int));
+    sp_free(Cp);
+    iVec_free(Ci);
+    return C;
+}
+
+/* Random cross-check: the gather rewrite must be byte-identical to the
+ * original has_overlap scan. */
+const char *test_block_left_multiply_matches_reference_random(void)
+{
+    srand(42);
+    int n = 15, p = 3, k = 8;
+    int iwork_size;
+
+    for (int trial = 0; trial < 5; trial++)
+    {
+        CSR_matrix *A = new_csr_random(20, n, 0.2);
+        CSR_matrix *G = new_csr_random(n * p, k, 0.15);
+
+        iwork_size = G->n;
+        int *iwork =
+            (int *) sp_malloc((iwork_size > 0 ? iwork_size : 1) * sizeof(int));
+        CSC_matrix *J = csr_to_csc_alloc(G, iwork);
+        sp_free(iwork);
+
+        CSC_matrix *C = block_left_multiply_fill_sparsity(A, J, p);
+        CSC_matrix *C_ref = block_left_multiply_fill_sparsity_ref(A, J, p);
+
+        mu_assert("random block sparsity nnz mismatch", C->nnz == C_ref->nnz);
+        mu_assert("random block sparsity col pointers mismatch",
+                  cmp_int_array(C->p, C_ref->p, J->n + 1));
+        mu_assert("random block sparsity row indices mismatch",
+                  cmp_int_array(C->i, C_ref->i, C_ref->nnz));
+
+        free_CSC_matrix(C);
+        free_CSC_matrix(C_ref);
+        free_CSC_matrix(J);
+        free_CSR_matrix(G);
+        free_CSR_matrix(A);
+    }
+    return NULL;
+}
+
+/* Dedup + ordering for csr_csc_matmul_alloc: A's row hits the same B column
+ * through several B rows (dedup), with B's CSR row lists interleaved so a
+ * missing sort would emit columns out of ascending order. */
+const char *test_csr_csc_matmul_alloc_dedup_order(void)
+{
+    /* A is 1x2 CSR_matrix: [1.0  1.0] */
+    CSR_matrix *A = new_CSR_matrix(1, 2, 2);
+    double Ax[2] = {1.0, 1.0};
+    int Ai[2] = {0, 1};
+    int Ap[2] = {0, 2};
+    memcpy(A->x, Ax, 2 * sizeof(double));
+    memcpy(A->i, Ai, 2 * sizeof(int));
+    memcpy(A->p, Ap, 2 * sizeof(int));
+
+    /* B is 2x3 CSC_matrix:
+     * [1.0  0.0  1.0]     CSR row 0: cols {0, 2}
+     * [0.0  1.0  1.0]     CSR row 1: cols {1, 2}
+     * Gathering rows 0 then 1 visits cols 0,2 then 1,2 — col 2 twice (dedup)
+     * and out of order (sort). Expected: cols {0, 1, 2} ascending. */
+    CSC_matrix *B = new_CSC_matrix(2, 3, 4);
+    double Bx[4] = {1.0, 1.0, 1.0, 1.0};
+    int Bi[4] = {0, 1, 0, 1};
+    int Bp[4] = {0, 1, 2, 4};
+    memcpy(B->x, Bx, 4 * sizeof(double));
+    memcpy(B->i, Bi, 4 * sizeof(int));
+    memcpy(B->p, Bp, 4 * sizeof(int));
+
+    CSR_matrix *C = csr_csc_matmul_alloc(A, B);
+
+    int expected_p[2] = {0, 3};
+    int expected_i[3] = {0, 1, 2};
+
+    mu_assert("C dims incorrect", C->m == 1 && C->n == 3 && C->nnz == 3);
+    mu_assert("C row pointers incorrect", cmp_int_array(C->p, expected_p, 2));
+    mu_assert("C col indices incorrect", cmp_int_array(C->i, expected_i, 3));
+
+    free_CSR_matrix(C);
+    free_CSR_matrix(A);
+    free_CSC_matrix(B);
+    return NULL;
+}
+
+/* Reference implementation of csr_csc_matmul_alloc (the original full
+ * row-times-column has_overlap loop) for the random cross-check. */
+static CSR_matrix *csr_csc_matmul_alloc_ref(const CSR_matrix *A, const CSC_matrix *B)
+{
+    int m = A->m;
+    int p = B->n;
+
+    int *Cp = (int *) sp_malloc((m + 1) * sizeof(int));
+    iVec *Ci = iVec_new(m);
+    Cp[0] = 0;
+
+    int nnz = 0;
+    for (int i = 0; i < m; i++)
+    {
+        int len_a = A->p[i + 1] - A->p[i];
+        for (int j = 0; j < p; j++)
+        {
+            int len_b = B->p[j + 1] - B->p[j];
+            if (has_overlap(A->i + A->p[i], len_a, B->i + B->p[j], len_b, 0))
+            {
+                iVec_append(Ci, j);
+                nnz++;
+            }
+        }
+        Cp[i + 1] = nnz;
+    }
+
+    CSR_matrix *C = new_CSR_matrix(m, p, nnz);
+    memcpy(C->p, Cp, (m + 1) * sizeof(int));
+    memcpy(C->i, Ci->data, nnz * sizeof(int));
+    sp_free(Cp);
+    iVec_free(Ci);
+    return C;
+}
+
+/* Random cross-check: the gather rewrite must be byte-identical to the
+ * original has_overlap pair loop. */
+const char *test_csr_csc_matmul_alloc_matches_reference_random(void)
+{
+    srand(7);
+
+    for (int trial = 0; trial < 5; trial++)
+    {
+        CSR_matrix *A = new_csr_random(20, 15, 0.2);
+        CSR_matrix *G = new_csr_random(15, 12, 0.2);
+
+        int *iwork = (int *) sp_malloc(G->n * sizeof(int));
+        CSC_matrix *B = csr_to_csc_alloc(G, iwork);
+        sp_free(iwork);
+
+        CSR_matrix *C = csr_csc_matmul_alloc(A, B);
+        CSR_matrix *C_ref = csr_csc_matmul_alloc_ref(A, B);
+
+        mu_assert("random matmul sparsity nnz mismatch", C->nnz == C_ref->nnz);
+        mu_assert("random matmul sparsity row pointers mismatch",
+                  cmp_int_array(C->p, C_ref->p, A->m + 1));
+        mu_assert("random matmul sparsity col indices mismatch",
+                  cmp_int_array(C->i, C_ref->i, C_ref->nnz));
+
+        free_CSR_matrix(C);
+        free_CSR_matrix(C_ref);
+        free_CSC_matrix(B);
+        free_CSR_matrix(G);
+        free_CSR_matrix(A);
+    }
     return NULL;
 }
 


### PR DESCRIPTION
## What changed

`block_left_multiply_fill_sparsity` and `csr_csc_matmul_alloc` build the output
sparsity pattern of `C = A @ B`. Previously they were input-driven: every
candidate output entry `(i, j)` ran a `has_overlap` merge-scan of row `i` of A
against column `j` of B — `m x p` scans regardless of how sparse the operands
are. They are now output-driven (the symbolic phase of Gustavson's sparse
matmul): an output row's pattern is the union of the operand index lists its
entries select, so we only walk index lists that exist. Candidates are
deduplicated with a generation-stamped workspace and sorted, so the produced
pattern is **byte-identical** to the old code's. The shared gather lives in one
helper, `sorted_pattern_union`. Each function builds one transposed view of the
constant operand up front; both functions run once per problem at derivative-
structure initialization, so that cost is amortized. The per-iteration
`*_fill_values` paths are untouched.

Complexity per output row goes from O(m) (resp. O(p)) overlap scans to
O(flops for that row + sort of its pattern).

## Correctness

- The gather reproduces the old scan's output exactly (same dedup semantics,
  same ascending order). Unit tests include hand-built cases where a missing
  dedup or missing sort would each fail deterministically, plus randomized
  cross-checks against the original `has_overlap` implementation (kept verbatim
  in the test file as a reference): identical `p`/`i` arrays asserted over
  random trials for both functions.
- Full engine test suite passes (401 tests).
- End-to-end A/B: 17 problems mirroring the cvxpy `nlp_tests` suite and DNLP
  doc examples were run through the cvxpy -> sparsediffpy path against two
  builds identical except for this file. Objective, gradient, constraint
  values, and the full Jacobian and Hessian sparsity patterns **and values**
  are exactly equal (`np.array_equal`) on every problem, in two independent
  runs. (Comparison is NaN-aware: two division-by-quad_form formulations
  evaluate to NaN at the harness's arbitrary evaluation point — identically,
  in the same positions, in both builds.)

## Benchmarks (DNLP suite, end-to-end through cvxpy)

"kernel" = wall time inside the two rewritten functions, measured with
`CLOCK_MONOTONIC` accumulators compiled identically into both builds
(benchmark-only instrumentation, not part of this PR). "deriv. init" =
`problem_init_jacobian_coo` + `problem_init_hessian_coo_lower_triangular`.
Times are min over 2 independent runs x 3 in-process repetitions.

| problem | kernel calls (block / csr@csc) | kernel old (ms) | kernel new (ms) | kernel speedup | deriv. init old (ms) | deriv. init new (ms) | init speedup |
|---|:-:|--:|--:|--:|--:|--:|--:|
| `A @ x == b`, sparse A 5000x5000 (0.2%) | 1 / 0 | 973.25 | 1.29 | **752x** | 975.01 | 2.55 | 381.84x |
| signal recovery, sparse A 2000x6000 (1%) | 1 / 0 | 1,848.06 | 2.70 | **683x** | 1,896.65 | 50.49 | 37.57x |
| `convolve(k, x)`, kernel 100, signal 2000 | 0 / 1 | 939.28 | 3.08 | **305x** | 1,814.09 | 882.11 | 2.06x |
| logistic regression, sparse A 10000x2000 (0.5%) | 1 / 0 | 745.03 | 1.93 | **386x** | 1,550.35 | 809.82 | 1.91x |
| logistic regression, sparse A 2000x785 (1%) | 1 / 0 | 45.00 | 0.33 | **136x** | 98.26 | 54.04 | 1.82x |
| `A @ x == b`, sparse A 1000x1000 (1%) | 1 / 0 | 33.83 | 0.23 | **147x** | 34.09 | 0.46 | 73.69x |
| AC power flow, 9-bus (test suite) | 0 / 2 | <0.1 | <0.1 | -- | 0.53 | 0.52 | 1.02x |
| `min \|X @ Y - C\|_F^2`, 40x20x30 | 0 / 0 | ~0 | ~0 | -- | 218.33 | 216.98 | 1.01x |
| `t == sum(X @ Y)` (test suite, 5x7x11) | 0 / 0 | ~0 | ~0 | -- | 0.07 | 0.07 | 1.01x |
| risk parity, n=8 (test suite) | 0 / 0 | ~0 | ~0 | -- | 0.06 | 0.06 | 1.01x |
| Sharpe ratio, n=100 (test suite) | 0 / 0 | ~0 | ~0 | -- | 0.18 | 0.19 | 0.99x |
| signal recovery, dense A 200x600 | 0 / 0 | ~0 | ~0 | -- | 0.92 | 0.93 | 0.99x |
| max entropy `sum(entr(A @ q))`, dense A 100x100 | 0 / 0 | ~0 | ~0 | -- | 0.03 | 0.02 | 1.05x |
| chemical equilibrium (doc example, verbatim) | 0 / 0 | ~0 | ~0 | -- | 0.03 | 0.03 | 1.01x |
| `trace(exp(A @ X))`, dense A 10x10 (stress suite) | 0 / 0 | ~0 | ~0 | -- | 0.11 | 0.11 | 1.02x |
| `sum(exp(X @ A))`, dense A 10x10 (stress suite) | 0 / 0 | ~0 | ~0 | -- | 0.13 | 0.13 | 1.03x |
| path planning w/ obstacles, n=50 (doc example) | 0 / 0 | ~0 | ~0 | -- | 0.26 | 0.26 | 0.99x |
| **total** | | **4,584.48** | **9.59** | **478x** | **6,589.09** | **2,018.76** | **3.26x** |

Reading the table honestly:

- On sparse problems at realistic scale the old kernels **were** the
  init-phase bottleneck (e.g. 97% of signal-recovery init) and are now
  negligible; where init speedup is below the kernel speedup, the remaining
  time is in other init work (e.g. Hessian assembly) that this PR does not
  touch.
- The call-count column shows which problems reach these kernels at all:
  only sparse constant matmuls (block fill) and `convolve` / power flow
  (csr@csc). Most suite problems at their natural unit-test sizes use dense
  data, which takes the `permuted_dense` path (0 calls) — on all of those,
  outputs are identical and timings differ only by noise (0.99x-1.05x).
- The bivariate `X @ Y` problems also made 0 calls: the matmul atom's
  `csr_csc_matmul_alloc` is on its composite-children Hessian path, and these
  tests use leaf variables.
- Four more suite problems (`log_sum_exp` x2, `huber`, `sum_largest`) could
  not run on the direct C-problem harness because those atoms are lowered by
  the dnlp2smooth reduction before reaching the engine in real solves; their
  lowered forms use the same dense-path atoms as the rows above.
- Per-iteration eval times are unaffected: an interleaved A/B/A/B measurement
  of the largest eval (bivariate `X @ Y` Hessian) shows the new build within
  noise (marginally faster: 157-159 ms vs 162-164 ms).
- The engine's own `PROFILE_ONLY` suite agrees: `profile_left_matmul` Jacobian
  init 0.238 s -> 0.028 s; `profile_memory` derivative-structure phase
  2.22 s -> 1.91 s; everything else unchanged.

## Known trade-off

Kernel-level microbenchmarks (old vs new on random matrices, outputs verified
identical in every case) show the win grows as operands get sparser (230x at
0.1% density, 11-23x at 1%, size-independent), but when **both** operands are
dense-ish the old scan is faster: at 20% density old wins ~2x, and on fully
dense inputs ~70x (its `has_overlap` early-exits on the first match, O(1) per
pair, while the gather does full O(n) work per pair). This regime is not
reachable through cvxpy for constant matmuls — `SPARSE_DENSITY_THRESHOLD =
0.05` routes denser constants to the dense (`permuted_dense`) path — and dense
operands should use that path anyway. If we ever want insurance, a cheap
per-row guard (sum the selected index-list lengths; fall back to the
`has_overlap` scan when it exceeds the output width) is possible as follow-up.

## Environment

Intel Core i7-8850H (2.6 GHz), macOS 15.7.7, Apple clang 15, Release (-O3,
-DNDEBUG), Python 3.14 / cvxpy nlp branch. Benchmark harness: two sparsediffpy
builds identical except `src/utils/linalg_sparse_matmuls.c` (old = `main`,
new = this branch), swapped via PYTHONPATH.
