### PR TITLE
Expose COO-pattern reuse: problem_init_jacobian_coo_from + Hessian analog

### DIFF
--- a/include/problem.h
+++ b/include/problem.h
@@ -81,6 +81,14 @@ void problem_init_jacobian(problem *prob);
 void problem_init_hessian(problem *prob);
 void problem_init_derivatives(problem *prob);
 void problem_init_jacobian_coo(problem *prob);
+/* Like problem_init_jacobian_coo, but adopts a caller-provided COO pattern
+ * (as previously returned for a structurally identical problem) instead of
+ * expanding it from the CSR. The expression-level Jacobian structures are
+ * still initialized; only the COO view construction is skipped. Returns 0 on
+ * success, -1 if nnz does not match this problem's Jacobian (the pattern is
+ * then ignored and no COO view is created). */
+int problem_init_jacobian_coo_from(problem *prob, const int *rows,
+                                   const int *cols, int nnz);
 void problem_init_hessian_coo_lower_triangular(problem *prob);
 void free_problem(problem *prob);
 

--- a/include/problem.h
+++ b/include/problem.h
@@ -90,6 +90,12 @@ void problem_init_jacobian_coo(problem *prob);
 int problem_init_jacobian_coo_from(problem *prob, const int *rows,
                                    const int *cols, int nnz);
 void problem_init_hessian_coo_lower_triangular(problem *prob);
+/* Hessian analog of problem_init_jacobian_coo_from: adopts a caller-provided
+ * lower-triangular COO pattern. The value map is still derived from the CSR
+ * (evaluation needs it); same 0 / -1 contract. */
+int problem_init_hessian_coo_lower_triangular_from(problem *prob,
+                                                   const int *rows,
+                                                   const int *cols, int nnz);
 void free_problem(problem *prob);
 
 void problem_register_params(problem *prob, expr **param_nodes, int n_param_nodes);

--- a/include/utils/COO_matrix.h
+++ b/include/utils/COO_matrix.h
@@ -57,6 +57,15 @@ COO_matrix *new_COO_matrix_from_pattern(const CSR_matrix *A, const int *rows,
    update values without recomputing structure. */
 COO_matrix *new_COO_matrix_lower_triangular(const CSR_matrix *A);
 
+/* Lower-triangular COO from a caller-provided pattern (copied). value_map is
+   still derived from A (evaluation needs it), but the counting pass and the
+   row/col writes are skipped. The pattern must be A's own lower-triangular
+   pattern in row-major order; only nnz is validated (NULL on mismatch). */
+COO_matrix *new_COO_matrix_lower_triangular_from_pattern(const CSR_matrix *A,
+                                                         const int *rows,
+                                                         const int *cols,
+                                                         int nnz);
+
 /* Refresh COO values from a new CSR_matrix value array using value_map */
 void refresh_lower_triangular_coo(COO_matrix *coo, const double *vals);
 

--- a/include/utils/COO_matrix.h
+++ b/include/utils/COO_matrix.h
@@ -46,6 +46,12 @@ typedef struct COO_matrix
 /* COO from CSR */
 COO_matrix *new_COO_matrix(const CSR_matrix *A);
 
+/* COO from a caller-provided pattern (copied), values taken from A->x. The
+   pattern must be A's own pattern in row-major (CSR) order; the caller
+   certifies this, only nnz is validated (returns NULL on mismatch). */
+COO_matrix *new_COO_matrix_from_pattern(const CSR_matrix *A, const int *rows,
+                                        const int *cols, int nnz);
+
 /* Construct COO containing only the lower-triangular entries (col <= row) of a
    symmetric CSR. Populates value_map so that refresh_lower_triangular_coo can
    update values without recomputing structure. */

--- a/src/problem.c
+++ b/src/problem.c
@@ -284,6 +284,22 @@ void problem_init_jacobian_coo(problem *prob)
     prob->stats.time_init_derivatives += GET_ELAPSED_SECONDS(timer);
 }
 
+int problem_init_jacobian_coo_from(problem *prob, const int *rows,
+                                   const int *cols, int nnz)
+{
+    problem_init_jacobian(prob);
+    if (prob->jacobian_coo != NULL) return 0;
+
+    Timer timer;
+    clock_gettime(CLOCK_MONOTONIC, &timer.start);
+    prob->jacobian_coo =
+        new_COO_matrix_from_pattern(prob->jacobian, rows, cols, nnz);
+    clock_gettime(CLOCK_MONOTONIC, &timer.end);
+    prob->stats.time_init_derivatives += GET_ELAPSED_SECONDS(timer);
+
+    return prob->jacobian_coo != NULL ? 0 : -1;
+}
+
 void problem_init_hessian_coo_lower_triangular(problem *prob)
 {
     problem_init_hessian(prob);

--- a/src/problem.c
+++ b/src/problem.c
@@ -313,6 +313,23 @@ void problem_init_hessian_coo_lower_triangular(problem *prob)
     prob->stats.time_init_derivatives += GET_ELAPSED_SECONDS(timer);
 }
 
+int problem_init_hessian_coo_lower_triangular_from(problem *prob,
+                                                   const int *rows,
+                                                   const int *cols, int nnz)
+{
+    problem_init_hessian(prob);
+    if (prob->lagrange_hessian_coo != NULL) return 0;
+
+    Timer timer;
+    clock_gettime(CLOCK_MONOTONIC, &timer.start);
+    prob->lagrange_hessian_coo = new_COO_matrix_lower_triangular_from_pattern(
+        prob->lagrange_hessian, rows, cols, nnz);
+    clock_gettime(CLOCK_MONOTONIC, &timer.end);
+    prob->stats.time_init_derivatives += GET_ELAPSED_SECONDS(timer);
+
+    return prob->lagrange_hessian_coo != NULL ? 0 : -1;
+}
+
 void problem_init_derivatives(problem *prob)
 {
     problem_init_jacobian(prob);

--- a/src/utils/COO_matrix.c
+++ b/src/utils/COO_matrix.c
@@ -110,6 +110,48 @@ COO_matrix *new_COO_matrix_lower_triangular(const CSR_matrix *A)
     return coo;
 }
 
+COO_matrix *new_COO_matrix_lower_triangular_from_pattern(const CSR_matrix *A,
+                                                         const int *rows,
+                                                         const int *cols,
+                                                         int nnz)
+{
+    COO_matrix *coo = (COO_matrix *) sp_malloc(sizeof(COO_matrix));
+    coo->m = A->m;
+    coo->n = A->n;
+    coo->nnz = nnz;
+    coo->rows = (int *) sp_malloc(nnz * sizeof(int));
+    coo->cols = (int *) sp_malloc(nnz * sizeof(int));
+    coo->x = (double *) sp_malloc(nnz * sizeof(double));
+    coo->value_map = (int *) sp_malloc(nnz * sizeof(int));
+
+    /* value_map must still be derived from A; the counting pass and the
+       row/col writes are what the provided pattern saves. */
+    int idx = 0;
+    for (int r = 0; r < A->m; r++)
+    {
+        for (int k = A->p[r]; k < A->p[r + 1]; k++)
+        {
+            if (A->i[k] <= r)
+            {
+                if (idx == nnz) goto mismatch;
+                coo->x[idx] = A->x[k];
+                coo->value_map[idx] = k;
+                idx++;
+            }
+        }
+    }
+    if (idx != nnz) goto mismatch;
+
+    memcpy(coo->rows, rows, nnz * sizeof(int));
+    memcpy(coo->cols, cols, nnz * sizeof(int));
+
+    return coo;
+
+mismatch:
+    free_COO_matrix(coo);
+    return NULL;
+}
+
 void refresh_lower_triangular_coo(COO_matrix *coo, const double *vals)
 {
     for (int i = 0; i < coo->nnz; i++)

--- a/src/utils/COO_matrix.c
+++ b/src/utils/COO_matrix.c
@@ -45,6 +45,27 @@ COO_matrix *new_COO_matrix(const CSR_matrix *A)
     return coo;
 }
 
+COO_matrix *new_COO_matrix_from_pattern(const CSR_matrix *A, const int *rows,
+                                        const int *cols, int nnz)
+{
+    if (nnz != A->nnz) return NULL;
+
+    COO_matrix *coo = (COO_matrix *) sp_malloc(sizeof(COO_matrix));
+    coo->m = A->m;
+    coo->n = A->n;
+    coo->nnz = nnz;
+    coo->rows = (int *) sp_malloc(nnz * sizeof(int));
+    coo->cols = (int *) sp_malloc(nnz * sizeof(int));
+    coo->x = (double *) sp_malloc(nnz * sizeof(double));
+    coo->value_map = NULL;
+
+    memcpy(coo->rows, rows, nnz * sizeof(int));
+    memcpy(coo->cols, cols, nnz * sizeof(int));
+    memcpy(coo->x, A->x, nnz * sizeof(double));
+
+    return coo;
+}
+
 COO_matrix *new_COO_matrix_lower_triangular(const CSR_matrix *A)
 {
     /* Pass 1: count lower-triangular entries (col <= row) */

--- a/tests/all_tests.c
+++ b/tests/all_tests.c
@@ -514,6 +514,7 @@ int main(void)
     mu_run_test(test_problem_gradient, tests_run);
     mu_run_test(test_problem_jacobian, tests_run);
     mu_run_test(test_problem_jacobian_multi, tests_run);
+    mu_run_test(test_problem_jacobian_coo_from, tests_run);
     mu_run_test(test_problem_constraint_forward, tests_run);
     mu_run_test(test_problem_hessian, tests_run);
     mu_run_test(test_problem_hessian_sum_exp_left_matmul_dense_transpose, tests_run);

--- a/tests/all_tests.c
+++ b/tests/all_tests.c
@@ -515,6 +515,7 @@ int main(void)
     mu_run_test(test_problem_jacobian, tests_run);
     mu_run_test(test_problem_jacobian_multi, tests_run);
     mu_run_test(test_problem_jacobian_coo_from, tests_run);
+    mu_run_test(test_problem_hessian_coo_from, tests_run);
     mu_run_test(test_problem_constraint_forward, tests_run);
     mu_run_test(test_problem_hessian, tests_run);
     mu_run_test(test_problem_hessian_sum_exp_left_matmul_dense_transpose, tests_run);

--- a/tests/problem/test_problem.h
+++ b/tests/problem/test_problem.h
@@ -329,6 +329,75 @@ const char *test_problem_jacobian_coo_from(void)
 }
 
 /*
+ * Test problem_init_hessian_coo_lower_triangular_from: the Hessian analog of
+ * test_problem_jacobian_coo_from. The adopted lower-triangular pattern must
+ * match the engine-computed one including the value map (evaluation depends
+ * on it), and a wrong-sized pattern must be rejected.
+ */
+const char *test_problem_hessian_coo_from(void)
+{
+    int n_vars = 3;
+    double u[3] = {1.0, 2.0, 3.0};
+    double w[3] = {1.0, 2.0, 3.0};
+
+    /* Reference problem: sum(log(x)) objective, exp(x) constraint */
+    expr *x_a = new_variable(3, 1, 0, n_vars);
+    expr *obj_a = new_sum(new_log(x_a), -1);
+    expr *cons_a[1] = {new_exp(x_a)};
+    problem *prob_a = new_problem(obj_a, cons_a, 1, false);
+    problem_init_hessian_coo_lower_triangular(prob_a);
+    COO_matrix *coo_a = prob_a->lagrange_hessian_coo;
+
+    /* Identical problem adopts the reference pattern */
+    expr *x_b = new_variable(3, 1, 0, n_vars);
+    expr *obj_b = new_sum(new_log(x_b), -1);
+    expr *cons_b[1] = {new_exp(x_b)};
+    problem *prob_b = new_problem(obj_b, cons_b, 1, false);
+    int status = problem_init_hessian_coo_lower_triangular_from(
+        prob_b, coo_a->rows, coo_a->cols, coo_a->nnz);
+    mu_assert("hess coo_from failed", status == 0);
+    COO_matrix *coo_b = prob_b->lagrange_hessian_coo;
+    mu_assert("hess coo missing", coo_b != NULL);
+    mu_assert("hess coo nnz wrong", coo_b->nnz == coo_a->nnz);
+    mu_assert("hess coo rows wrong",
+              cmp_int_array(coo_b->rows, coo_a->rows, coo_a->nnz));
+    mu_assert("hess coo cols wrong",
+              cmp_int_array(coo_b->cols, coo_a->cols, coo_a->nnz));
+    mu_assert("hess value_map wrong",
+              cmp_int_array(coo_b->value_map, coo_a->value_map, coo_a->nnz));
+
+    /* Evaluation through the value map must be identical */
+    problem_objective_forward(prob_a, u);
+    problem_constraint_forward(prob_a, u);
+    problem_hessian(prob_a, 2.0, w);
+    refresh_lower_triangular_coo(coo_a, prob_a->lagrange_hessian->x);
+
+    problem_objective_forward(prob_b, u);
+    problem_constraint_forward(prob_b, u);
+    problem_hessian(prob_b, 2.0, w);
+    refresh_lower_triangular_coo(coo_b, prob_b->lagrange_hessian->x);
+    mu_assert("hess vals differ",
+              cmp_double_array(coo_b->x, coo_a->x, coo_a->nnz));
+
+    /* A wrong-sized pattern is rejected and leaves no COO view */
+    expr *x_c = new_variable(3, 1, 0, n_vars);
+    expr *obj_c = new_sum(new_log(x_c), -1);
+    expr *cons_c[1] = {new_exp(x_c)};
+    problem *prob_c = new_problem(obj_c, cons_c, 1, false);
+    status = problem_init_hessian_coo_lower_triangular_from(
+        prob_c, coo_a->rows, coo_a->cols, coo_a->nnz - 1);
+    mu_assert("hess size mismatch not rejected", status == -1);
+    mu_assert("hess coo created despite mismatch",
+              prob_c->lagrange_hessian_coo == NULL);
+
+    free_problem(prob_a);
+    free_problem(prob_b);
+    free_problem(prob_c);
+
+    return 0;
+}
+
+/*
  * Test problem_hessian: Lagrange Hessian of:
  *   Objective: sum(log(x)) where x is 3x1
  *   Constraint 1: exp(x)

--- a/tests/problem/test_problem.h
+++ b/tests/problem/test_problem.h
@@ -269,6 +269,66 @@ const char *test_problem_jacobian_multi(void)
 }
 
 /*
+ * Test problem_init_jacobian_coo_from: a second, structurally identical
+ * problem adopts the COO pattern computed by the first one. The adopted
+ * pattern must match what the engine would compute itself, evaluation must
+ * be unaffected, and a wrong-sized pattern must be rejected.
+ */
+const char *test_problem_jacobian_coo_from(void)
+{
+    int n_vars = 2;
+    double u[2] = {2.0, 4.0};
+
+    /* Reference problem: engine computes the COO pattern itself */
+    expr *x_a = new_variable(2, 1, 0, n_vars);
+    expr *obj_a = new_sum(new_log(x_a), -1);
+    expr *cons_a[2] = {new_log(x_a), new_exp(x_a)};
+    problem *prob_a = new_problem(obj_a, cons_a, 2, false);
+    problem_init_jacobian_coo(prob_a);
+    COO_matrix *coo_a = prob_a->jacobian_coo;
+
+    /* Identical problem adopts the reference pattern */
+    expr *x_b = new_variable(2, 1, 0, n_vars);
+    expr *obj_b = new_sum(new_log(x_b), -1);
+    expr *cons_b[2] = {new_log(x_b), new_exp(x_b)};
+    problem *prob_b = new_problem(obj_b, cons_b, 2, false);
+    int status = problem_init_jacobian_coo_from(prob_b, coo_a->rows,
+                                                coo_a->cols, coo_a->nnz);
+    mu_assert("coo_from failed", status == 0);
+    mu_assert("coo missing", prob_b->jacobian_coo != NULL);
+    mu_assert("coo nnz wrong", prob_b->jacobian_coo->nnz == coo_a->nnz);
+    mu_assert("coo rows wrong",
+              cmp_int_array(prob_b->jacobian_coo->rows, coo_a->rows, coo_a->nnz));
+    mu_assert("coo cols wrong",
+              cmp_int_array(prob_b->jacobian_coo->cols, coo_a->cols, coo_a->nnz));
+
+    /* Evaluation is unaffected by how the COO view was initialized */
+    problem_constraint_forward(prob_a, u);
+    problem_jacobian(prob_a);
+    problem_constraint_forward(prob_b, u);
+    problem_jacobian(prob_b);
+    mu_assert("jac vals differ", cmp_double_array(prob_b->jacobian->x,
+                                                  prob_a->jacobian->x,
+                                                  prob_a->jacobian->nnz));
+
+    /* A wrong-sized pattern is rejected and leaves no COO view */
+    expr *x_c = new_variable(2, 1, 0, n_vars);
+    expr *obj_c = new_sum(new_log(x_c), -1);
+    expr *cons_c[1] = {new_log(x_c)};
+    problem *prob_c = new_problem(obj_c, cons_c, 1, false);
+    status = problem_init_jacobian_coo_from(prob_c, coo_a->rows, coo_a->cols,
+                                            coo_a->nnz);
+    mu_assert("size mismatch not rejected", status == -1);
+    mu_assert("coo created despite mismatch", prob_c->jacobian_coo == NULL);
+
+    free_problem(prob_a);
+    free_problem(prob_b);
+    free_problem(prob_c);
+
+    return 0;
+}
+
+/*
  * Test problem_hessian: Lagrange Hessian of:
  *   Objective: sum(log(x)) where x is 3x1
  *   Constraint 1: exp(x)


### PR DESCRIPTION
## What

Two new entry points that let a caller initialize a problem's derivative COO views from a previously computed pattern instead of recomputing it:

- `problem_init_jacobian_coo_from(prob, rows, cols, nnz)` — adopts the Jacobian COO pattern, skipping the CSR->COO expansion.
- `problem_init_hessian_coo_lower_triangular_from(prob, rows, cols, nnz)` — Hessian analog; the value map is still derived from the CSR (`refresh_lower_triangular_coo` needs it), so the provided pattern saves the counting pass and the row/col writes.

Plus the underlying constructors `new_COO_matrix_from_pattern` / `new_COO_matrix_lower_triangular_from_pattern`.

## Why

Callers that rebuild a structurally identical problem — cvxpy's `ignore_dpp` path rebuilds the capsule on every parametric re-solve — already hold the derivative patterns from the previous build. Fetching them again costs the COO construction plus an array round-trip per solve; on a 1M-var parametric LP the Jacobian side alone is ~45ms of a ~350ms rebuild.

## Semantics

- Expression-level derivative init still runs (evaluation needs the per-node structures); only the COO view construction is shortened.
- Patterns are validated by nnz: on mismatch the functions return -1 and leave no COO view, so a stale pattern fails loudly instead of silently misaligning values. Row-major ordering is certified by the caller (it is the engine's own output for the identical structure).
- Returns 0 on success; no behavior change for any existing entry point.

## Tests

`test_problem_jacobian_coo_from` and `test_problem_hessian_coo_from` (tests/problem/test_problem.h): adopted patterns match the engine-computed ones (including the Hessian value map), evaluation results are identical, and wrong-sized patterns are rejected. Full suite: 399 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)