### PR TITLE
Refresh composite param_source subtrees and retain registered parameter nodes

### DIFF
--- a/include/expr.h
+++ b/include/expr.h
@@ -66,6 +66,12 @@ typedef struct expr
     int d1, d2, size, n_vars, refcount, var_id;
     struct expr *left;
     struct expr *right;
+    /* Variable-free side subtree feeding cached parameter data (quad_form Q,
+       matmul A, scalar/vector mult a, convolve kernel). Not a regular child:
+       it is evaluated by the owning atom's refresh, not the main forward
+       recursion — but expr_set_needs_refresh must walk it like a child so
+       gating nodes inside it re-evaluate after a parameter update. */
+    struct expr *param_source;
 
     // ------------------------------------------------------------------------
     //                     oracle related quantities

--- a/include/subexpr.h
+++ b/include/subexpr.h
@@ -68,8 +68,7 @@ typedef struct quad_form_expr
     double *diag_w; /* length-n diagonal (= 2w) fed to BTDA on the dense path */
     int n;          /* quadratic dimension = left->size */
 
-    /* parametric dense path: param_source feeds Q each solve (NULL otherwise) */
-    expr *param_source;
+    /* parametric dense path: base.param_source feeds Q each solve */
 } quad_form_expr;
 
 /* Sum reduction along an axis */
@@ -139,15 +138,14 @@ typedef struct left_matmul_expr
     CSC_matrix *Jchild_CSC;
     CSC_matrix *J_CSC;
     int *csc_to_csr_work;
-    expr *param_source;
+    /* parametric A lives in base.param_source */
     void (*refresh_param_values)(struct left_matmul_expr *);
 } left_matmul_expr;
 
-/* Scalar multiplication: y = a * child where a comes from param_source */
+/* Scalar multiplication: y = a * child where a comes from base.param_source */
 typedef struct scalar_mult_expr
 {
     expr base;
-    expr *param_source;
 } scalar_mult_expr;
 
 /* Vector elementwise multiplication: y = a \circ child where a comes from
@@ -155,7 +153,6 @@ typedef struct scalar_mult_expr
 typedef struct vector_mult_expr
 {
     expr base;
-    expr *param_source;
 } vector_mult_expr;
 
 /* 1D convolution: y = conv(a, child) where a is a length-m kernel held by
@@ -166,10 +163,10 @@ typedef struct vector_mult_expr
 typedef struct convolve_expr
 {
     expr base;
-    expr *param_source; /* length-m kernel */
-    int m;              /* kernel length */
-    int n;              /* input length */
-    CSR_matrix *T;      /* (m+n-1) x n convolution matrix */
+    /* length-m kernel lives in base.param_source */
+    int m;         /* kernel length */
+    int n;         /* input length */
+    CSR_matrix *T; /* (m+n-1) x n convolution matrix */
     CSC_matrix *Jchild_CSC;
 } convolve_expr;
 

--- a/src/atoms/affine/convolve.c
+++ b/src/atoms/affine/convolve.c
@@ -39,20 +39,20 @@ static void forward(expr *node, const double *u)
 
     if (cnode->base.needs_parameter_refresh)
     {
-        cnode->param_source->forward(cnode->param_source, NULL);
+        cnode->base.param_source->forward(cnode->base.param_source, NULL);
         /* refresh the convolution matrix values if it exists (necessary to check
            for null in case someone calls forward before initializing the jacobian,
            which might happen when we expose Python bindings to SparseDiffEngine) */
         if (cnode->T != NULL)
         {
-            conv_matrix_fill_values(cnode->T, cnode->param_source->value);
+            conv_matrix_fill_values(cnode->T, cnode->base.param_source->value);
         }
         cnode->base.needs_parameter_refresh = false;
     }
 
     child->forward(child, u);
 
-    const double *a = cnode->param_source->value;
+    const double *a = cnode->base.param_source->value;
     const double *x = child->value;
     double *y = node->value;
 
@@ -72,7 +72,7 @@ static void jacobian_init_impl(expr *node)
     convolve_expr *cnode = (convolve_expr *) node;
     int m = cnode->m;
     int n = cnode->n;
-    const double *a = cnode->param_source->value;
+    const double *a = cnode->base.param_source->value;
 
     jacobian_init(child);
 
@@ -116,7 +116,7 @@ static void eval_wsum_hess(expr *node, const double *w)
 {
     expr *child = node->left;
     convolve_expr *cnode = (convolve_expr *) node;
-    const double *a = cnode->param_source->value;
+    const double *a = cnode->base.param_source->value;
     double *w_prime = node->work->dwork;
 
     /* w' = conv_matrix.T w, so w'[j] = sum_{i=0..m-1} a[i] * w[i + j]. */
@@ -145,7 +145,7 @@ static void free_type_data(expr *node)
     convolve_expr *cnode = (convolve_expr *) node;
     free_CSR_matrix(cnode->T);
     free_CSC_matrix(cnode->Jchild_CSC);
-    free_expr(cnode->param_source);
+    free_expr(cnode->base.param_source);
 }
 
 expr *new_convolve(expr *param_node, expr *child)
@@ -183,7 +183,7 @@ expr *new_convolve(expr *param_node, expr *child)
     node->left = child;
     expr_retain(child);
 
-    cnode->param_source = param_node;
+    cnode->base.param_source = param_node;
     expr_retain(param_node);
     cnode->m = m;
     cnode->n = n;

--- a/src/atoms/affine/left_matmul.c
+++ b/src/atoms/affine/left_matmul.c
@@ -54,7 +54,7 @@
 
 static void refresh_param_values(left_matmul_expr *lnode)
 {
-    if (lnode->param_source == NULL || !lnode->base.needs_parameter_refresh)
+    if (lnode->base.param_source == NULL || !lnode->base.needs_parameter_refresh)
     {
         return;
     }
@@ -68,9 +68,9 @@ static void forward(expr *node, const double *u)
     left_matmul_expr *lnode = (left_matmul_expr *) node;
 
     /* call forward on param_source if it exists and needs refresh */
-    if (lnode->param_source != NULL && lnode->base.needs_parameter_refresh)
+    if (lnode->base.param_source != NULL && lnode->base.needs_parameter_refresh)
     {
-        lnode->param_source->forward(lnode->param_source, NULL);
+        lnode->base.param_source->forward(lnode->base.param_source, NULL);
     }
 
     refresh_param_values(lnode);
@@ -99,14 +99,14 @@ static void free_type_data(expr *node)
     free_CSC_matrix(lnode->Jchild_CSC);
     free_CSC_matrix(lnode->J_CSC);
     sp_free(lnode->csc_to_csr_work);
-    free_expr(lnode->param_source);
+    free_expr(lnode->base.param_source);
 
     lnode->A = NULL;
     lnode->AT = NULL;
     lnode->Jchild_CSC = NULL;
     lnode->J_CSC = NULL;
     lnode->csc_to_csr_work = NULL;
-    lnode->param_source = NULL;
+    lnode->base.param_source = NULL;
 }
 
 /* jacobian_init for dense left matmul */
@@ -226,7 +226,7 @@ static void refresh_dense_left(left_matmul_expr *lnode)
     /* The parameter represents the A in left_matmul_dense(A, x) in column-major.
        In this diffengine, we store A in row-major order. Hence, param->vals
        actually corresponds to the transpose of A, and we transpose AT to get A. */
-    memcpy(lnode->AT->x, lnode->param_source->value, m * n * sizeof(double));
+    memcpy(lnode->AT->x, lnode->base.param_source->value, m * n * sizeof(double));
     A_transpose(lnode->A->x, lnode->AT->x, n, m);
 }
 
@@ -286,7 +286,7 @@ expr *new_left_matmul(expr *param_node, expr *u, const CSR_matrix *A)
     lnode->A->transpose_fill_values(lnode->A, lnode->AT);
 
     /* parameter support */
-    lnode->param_source = param_node;
+    lnode->base.param_source = param_node;
     if (param_node != NULL)
     {
         fprintf(stderr, "Error in new_left_matmul: parameter for a sparse matrix "
@@ -315,7 +315,7 @@ expr *new_left_matmul_dense(expr *param_node, expr *u, int m, int n,
     lnode->n_blocks = n_blocks;
 
     /* parameter support */
-    lnode->param_source = param_node;
+    lnode->base.param_source = param_node;
     if (param_node != NULL)
     {
         if (data != NULL)

--- a/src/atoms/affine/right_matmul.c
+++ b/src/atoms/affine/right_matmul.c
@@ -42,7 +42,7 @@ static void refresh_dense_right(left_matmul_expr *lnode)
 {
     /* This left_matmul_expr node corresponds to left multiplication with B = AT,
        where A is the original (m x n) matrix given to the right_matmul function.
-       Furthermore, lnode->param_source->value corresponds to the column-major
+       Furthermore, lnode->base.param_source->value corresponds to the column-major
        version of A, which is BT (an m x n matrix) */
 
     matrix *B = lnode->AT;
@@ -50,7 +50,7 @@ static void refresh_dense_right(left_matmul_expr *lnode)
     int m = B->n;
     int n = B->m;
 
-    memcpy(BT->x, lnode->param_source->value, m * n * sizeof(double));
+    memcpy(BT->x, lnode->base.param_source->value, m * n * sizeof(double));
     A_transpose(B->x, BT->x, m, n);
 }
 

--- a/src/atoms/affine/scalar_mult.c
+++ b/src/atoms/affine/scalar_mult.c
@@ -35,11 +35,11 @@ static void forward(expr *node, const double *u)
        its values) */
     if (snode->base.needs_parameter_refresh)
     {
-        snode->param_source->forward(snode->param_source, NULL);
+        snode->base.param_source->forward(snode->base.param_source, NULL);
         snode->base.needs_parameter_refresh = false;
     }
 
-    double a = snode->param_source->value[0];
+    double a = snode->base.param_source->value[0];
 
     /* child's forward pass */
     child->forward(child, u);
@@ -65,7 +65,7 @@ static void jacobian_init_impl(expr *node)
 static void eval_jacobian(expr *node)
 {
     expr *child = node->left;
-    double a = ((scalar_mult_expr *) node)->param_source->value[0];
+    double a = node->param_source->value[0];
 
     /* evaluate child */
     child->eval_jacobian(child);
@@ -93,7 +93,7 @@ static void eval_wsum_hess(expr *node, const double *w)
     expr *x = node->left;
     x->eval_wsum_hess(x, w);
 
-    double a = ((scalar_mult_expr *) node)->param_source->value[0];
+    double a = node->param_source->value[0];
     for (int j = 0; j < x->wsum_hess->nnz; j++)
     {
         node->wsum_hess->x[j] = a * x->wsum_hess->x[j];
@@ -108,10 +108,10 @@ static bool is_affine(const expr *node)
 static void free_type_data(expr *node)
 {
     scalar_mult_expr *snode = (scalar_mult_expr *) node;
-    if (snode->param_source != NULL)
+    if (snode->base.param_source != NULL)
     {
-        free_expr(snode->param_source);
-        snode->param_source = NULL;
+        free_expr(snode->base.param_source);
+        snode->base.param_source = NULL;
     }
 }
 
@@ -127,7 +127,7 @@ expr *new_scalar_mult(expr *param_node, expr *child)
     node->left = child;
     expr_retain(child);
 
-    mult_node->param_source = param_node;
+    mult_node->base.param_source = param_node;
     expr_retain(param_node);
 
     /* special case for handling broadcasting of constants correctly */

--- a/src/atoms/affine/vector_mult.c
+++ b/src/atoms/affine/vector_mult.c
@@ -35,11 +35,11 @@ static void forward(expr *node, const double *u)
        its values) */
     if (vnode->base.needs_parameter_refresh)
     {
-        vnode->param_source->forward(vnode->param_source, NULL);
+        vnode->base.param_source->forward(vnode->base.param_source, NULL);
         vnode->base.needs_parameter_refresh = false;
     }
 
-    const double *a = vnode->param_source->value;
+    const double *a = vnode->base.param_source->value;
 
     /* child's forward pass */
     child->forward(child, u);
@@ -65,7 +65,7 @@ static void jacobian_init_impl(expr *node)
 static void eval_jacobian(expr *node)
 {
     expr *x = node->left;
-    const double *a = ((vector_mult_expr *) node)->param_source->value;
+    const double *a = node->param_source->value;
 
     /* evaluate jacobian of child */
     x->eval_jacobian(x);
@@ -91,7 +91,7 @@ static void wsum_hess_init_impl(expr *node)
 static void eval_wsum_hess(expr *node, const double *w)
 {
     expr *x = node->left;
-    const double *a = ((vector_mult_expr *) node)->param_source->value;
+    const double *a = node->param_source->value;
 
     /* scale weights w by a */
     for (int i = 0; i < node->size; i++)
@@ -109,10 +109,10 @@ static void eval_wsum_hess(expr *node, const double *w)
 static void free_type_data(expr *node)
 {
     vector_mult_expr *vnode = (vector_mult_expr *) node;
-    if (vnode->param_source != NULL)
+    if (vnode->base.param_source != NULL)
     {
-        free_expr(vnode->param_source);
-        vnode->param_source = NULL;
+        free_expr(vnode->base.param_source);
+        vnode->base.param_source = NULL;
     }
 }
 
@@ -133,7 +133,7 @@ expr *new_vector_mult(expr *param_node, expr *child)
     node->left = child;
     expr_retain(child);
 
-    vnode->param_source = param_node;
+    vnode->base.param_source = param_node;
     expr_retain(param_node);
 
     /* special case for handling broadcasting of constants correctly */

--- a/src/atoms/other/quad_form.c
+++ b/src/atoms/other/quad_form.c
@@ -38,12 +38,12 @@
    Q is symmetric, so column-major == row-major and the copy is verbatim. */
 static void refresh_param_values_qf(quad_form_expr *qnode)
 {
-    if (qnode->param_source == NULL || !qnode->base.needs_parameter_refresh)
+    if (qnode->base.param_source == NULL || !qnode->base.needs_parameter_refresh)
     {
         return;
     }
     qnode->base.needs_parameter_refresh = false;
-    memcpy(qnode->Q->x, qnode->param_source->value,
+    memcpy(qnode->Q->x, qnode->base.param_source->value,
            (size_t) qnode->n * qnode->n * sizeof(double));
 }
 
@@ -53,9 +53,9 @@ static void forward(expr *node, const double *u)
     expr *x = node->left;
 
     /* refresh Q from the parameter if needed (no-op on the constant/sparse path) */
-    if (qnode->param_source != NULL && node->needs_parameter_refresh)
+    if (node->param_source != NULL && node->needs_parameter_refresh)
     {
-        qnode->param_source->forward(qnode->param_source, NULL);
+        node->param_source->forward(node->param_source, NULL);
     }
     refresh_param_values_qf(qnode);
 
@@ -375,8 +375,8 @@ static void free_type_data(expr *node)
         sp_free(qnode->diag_w);
         qnode->diag_w = NULL;
     }
-    free_expr(qnode->param_source);
-    qnode->param_source = NULL;
+    free_expr(qnode->base.param_source);
+    qnode->base.param_source = NULL;
 }
 
 static bool is_affine(const expr *node)
@@ -425,7 +425,7 @@ expr *new_quad_form_dense(expr *child, int n, const double *P_data,
     /* dwork stores Q @ x in the forward pass */
     node->work->dwork = (double *) sp_malloc(n * sizeof(double));
 
-    qnode->param_source = param_source;
+    qnode->base.param_source = param_source;
     if (param_source != NULL)
     {
         if (P_data != NULL)

--- a/src/expr.c
+++ b/src/expr.c
@@ -32,6 +32,7 @@ void init_expr(expr *node, int d1, int d2, int n_vars, forward_fn forward,
     node->size = d1 * d2;
     node->n_vars = n_vars;
     node->refcount = 0;
+    node->param_source = NULL;
     node->value = (double *) sp_calloc(d1 * d2, sizeof(double));
     node->var_id = NOT_A_VARIABLE;
     node->forward = forward;
@@ -115,6 +116,11 @@ void expr_set_needs_refresh(expr *node)
     node->work->jacobian_csc_filled = false;
     expr_set_needs_refresh(node->left);
     expr_set_needs_refresh(node->right);
+    /* param_source is a side subtree evaluated by the owning atom's refresh,
+       not the main forward recursion; without this walk, gating nodes inside
+       a composite source (e.g. a power node in Q = I/p) would keep serving
+       cached values after a parameter update. */
+    expr_set_needs_refresh(node->param_source);
 }
 
 void expr_retain(expr *node)

--- a/src/problem.c
+++ b/src/problem.c
@@ -371,7 +371,11 @@ void free_problem(problem *prob)
         print_end_message(&prob->stats);
     }
 
-    /* Free param_nodes array (weak refs, don't free the nodes) */
+    /* Release registered parameter nodes, then the array */
+    for (int i = 0; i < prob->n_param_nodes; i++)
+    {
+        free_expr(prob->param_nodes[i]);
+    }
     sp_free(prob->param_nodes);
 
     /* Free allocated arrays */
@@ -412,6 +416,11 @@ void problem_register_params(problem *prob, expr **param_nodes, int n_param_node
             exit(1);
         }
 
+        /* The problem owns its registered nodes: a parameter may appear in
+           no expression tree (its value consumed elsewhere), in which case
+           dropping the Python capsule would otherwise free it while it is
+           still referenced here. */
+        expr_retain(param_nodes[i]);
         prob->total_parameter_size += param_nodes[i]->size;
     }
 }

--- a/tests/all_tests.c
+++ b/tests/all_tests.c
@@ -529,6 +529,8 @@ int main(void)
     mu_run_test(test_param_fixed_skip_in_update, tests_run);
     mu_run_test(test_param_scalar_mult_problem_with_constant, tests_run);
     mu_run_test(test_param_convolve_problem, tests_run);
+    mu_run_test(test_param_composite_source_quad_form, tests_run);
+    mu_run_test(test_param_composite_source_left_matmul, tests_run);
 
     printf("\n--- Parameter + Broadcast Tests ---\n");
     mu_run_test(test_constant_broadcast_vector_mult, tests_run);

--- a/tests/problem/test_param_prob.h
+++ b/tests/problem/test_param_prob.h
@@ -618,4 +618,109 @@ const char *test_param_convolve_problem(void)
     return 0;
 }
 
+/* Composite param_source refresh: minimize x'Qx with Q = (1/p) * I fed to a
+   dense quad_form through a scalar_mult(power(p,-1), I) side subtree. The
+   scalar_mult inside the source gates on needs_parameter_refresh, so this
+   pins expr_set_needs_refresh walking param_source: without it the source
+   keeps serving the stale 1/p after problem_update_params. */
+const char *test_param_composite_source_quad_form(void)
+{
+    int n = 2;
+
+    expr *x = new_variable(2, 1, 0, n);
+    double theta[1] = {2.0};
+    expr *p = new_parameter(1, 1, 0, n, theta);
+    expr *recip = new_power(p, -1.0);
+    double eye_vals[4] = {1.0, 0.0, 0.0, 1.0};
+    expr *eye_const = new_parameter(2, 2, PARAM_FIXED, n, eye_vals);
+    expr *Q_src = new_scalar_mult(recip, eye_const);
+    expr *objective = new_quad_form_dense(x, 2, NULL, Q_src);
+    problem *prob = new_problem(objective, NULL, 0, false);
+
+    expr *param_nodes[1] = {p};
+    problem_register_params(prob, param_nodes, 1);
+    problem_init_derivatives(prob);
+
+    double x_vals[2] = {1.0, 2.0};
+
+    /* test 1: p=2 -> f = (1+4)/2, grad = 2x/2, hess = 2I/2 */
+    double obj_val = problem_objective_forward(prob, x_vals);
+    problem_gradient(prob);
+    problem_hessian(prob, 1.0, NULL);
+    mu_assert("vals fail", fabs(obj_val - 2.5) < 1e-10);
+    double grad[2] = {1.0, 2.0};
+    mu_assert("grad fail", cmp_double_array(prob->gradient_values, grad, 2));
+    double Hx[4] = {1.0, 0.0, 0.0, 1.0}; /* dense 2Q = 2I/p, CSC */
+    mu_assert("hess vals fail", cmp_double_array(prob->lagrange_hessian->x, Hx, 4));
+
+    /* test 2: p=4 -> the composite source must re-evaluate 1/p */
+    theta[0] = 4.0;
+    problem_update_params(prob, theta);
+    obj_val = problem_objective_forward(prob, x_vals);
+    problem_gradient(prob);
+    problem_hessian(prob, 1.0, NULL);
+    mu_assert("vals fail", fabs(obj_val - 1.25) < 1e-10);
+    grad[0] = 0.5;
+    grad[1] = 1.0;
+    mu_assert("grad fail", cmp_double_array(prob->gradient_values, grad, 2));
+    Hx[0] = 0.5;
+    Hx[3] = 0.5;
+    mu_assert("hess vals fail", cmp_double_array(prob->lagrange_hessian->x, Hx, 4));
+
+    free_problem(prob);
+
+    return 0;
+}
+
+/* Same staleness class for the matmul family: constraint A @ x with
+   A = (1/p) * C fed to left_matmul_dense through a gated composite source. */
+const char *test_param_composite_source_left_matmul(void)
+{
+    int n = 2;
+
+    expr *x = new_variable(2, 1, 0, n);
+    double theta[1] = {2.0};
+    expr *p = new_parameter(1, 1, 0, n, theta);
+    expr *recip = new_power(p, -1.0);
+    double C_vals[4] = {2.0, 4.0, 6.0, 8.0}; /* column-major C = [[2,6],[4,8]] */
+    expr *C_const = new_parameter(2, 2, PARAM_FIXED, n, C_vals);
+    expr *A_src = new_scalar_mult(recip, C_const);
+    expr *Ax = new_left_matmul_dense(A_src, x, 2, 2, NULL);
+    expr *objective = new_sum(new_log(x), -1);
+    expr *constraints[1] = {Ax};
+    problem *prob = new_problem(objective, constraints, 1, false);
+
+    expr *param_nodes[1] = {p};
+    problem_register_params(prob, param_nodes, 1);
+    problem_init_derivatives(prob);
+
+    double x_vals[2] = {1.0, 1.0};
+
+    /* test 1: p=2 -> A = C/2 = [[1,3],[2,4]] */
+    problem_constraint_forward(prob, x_vals);
+    problem_jacobian(prob);
+    double constrs[2] = {4.0, 6.0};
+    double Jx[4] = {1.0, 3.0, 2.0, 4.0};
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 2));
+    mu_assert("jac vals fail", cmp_double_array(prob->jacobian->x, Jx, 4));
+
+    /* test 2: p=4 -> A = C/4; the gated source must re-evaluate */
+    theta[0] = 4.0;
+    problem_update_params(prob, theta);
+    problem_constraint_forward(prob, x_vals);
+    problem_jacobian(prob);
+    constrs[0] = 2.0;
+    constrs[1] = 3.0;
+    Jx[0] = 0.5;
+    Jx[1] = 1.5;
+    Jx[2] = 1.0;
+    Jx[3] = 2.0;
+    mu_assert("vals fail", cmp_double_array(prob->constraint_values, constrs, 2));
+    mu_assert("jac vals fail", cmp_double_array(prob->jacobian->x, Jx, 4));
+
+    free_problem(prob);
+
+    return 0;
+}
+
 #endif /* TEST_PARAM_PROB_H */


### PR DESCRIPTION
The cvxpy `ignore_dpp` path now caches the compiled problem capsule and re-solves it after `problem_update_params`, instead of rebuilding it every solve. Reuse exposes two latent bugs — both invisible under build-solve-discard, where every node starts with fresh flags and values.

## 1. Propagate `needs_parameter_refresh` into `param_source` side subtrees

**Example:** `quad_over_lin(x, p)` — cvxpy canonicalizes the quadratic matrix as `Q = eye(n)/p`, which reaches the engine as `quad_form` with `param_source = scalar_mult(power(p,-1), I)`. After `update_params`, `expr_set_needs_refresh` walks only `left`/`right`, so the quad_form's flag is set but the *inner* `scalar_mult`'s is not. The quad_form duly calls `param_source->forward(...)`, but that no-ops at the inner gate — it multiplies by the cached `1/p_old`, and the re-solve silently uses the previous solve's Q. (Bare-Parameter sources work only because `update_params` memcpys into them directly; simple broadcast/promote sources have no gate.)

Fix: hoist `param_source` from the five atom subclass structs (quad_form, left/right_matmul, scalar/vector mult, convolve) into the base `expr` struct so the refresh walker traverses it like a child. Re-evaluating sources unconditionally instead would recompute per solver iteration rather than once per `update_params`.

## 2. Make the problem own its registered parameter nodes

**Example:** a parameter whose value is consumed outside the engine (cvxpy feeds `floor(t)`'s bound numerically) appears in **no** expression tree, so nothing retained it: dropping the Python capsule freed the node while `prob->param_nodes` still pointed at it, and the next cross-solve `problem_update_params` wrote into freed memory (reproducible segfault).

Fix: `problem_register_params` retains each node; `free_problem` releases them.

## Tests

- New C tests `test_param_composite_source_{quad_form,left_matmul}` build exactly the nested-gate structure above and assert values/gradients/Jacobian/Hessian after `update_params`; both fail without fix 1. Full suite: 399 pass.
- cvxpy canary: `test_ignore_dpp.py::test_symbolic_quad_matrix_refreshes_through_cache` (cached `quad_over_lin(x, p)` re-solved for p = 1 → 1000 → 1) fails without fix 1; fix 2's segfault reproduced on the unpatched engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
